### PR TITLE
OPENEUROPA-2053: Translations are by default saved onto the revision they started from

### DIFF
--- a/oe_translation.info.yml
+++ b/oe_translation.info.yml
@@ -5,9 +5,10 @@ package: OpenEuropa
 type: module
 core: 8.x
 dependencies:
-  - tmgmt
-  - tmgmt_content
-  - tmgmt_local
+  - tmgmt:tmgmt
+  - tmgmt:tmgmt_content
+  - tmgmt:tmgmt_local
+  - drupal:content_translation
 
 config_devel:
   install:

--- a/oe_translation.install
+++ b/oe_translation.install
@@ -6,6 +6,8 @@
  */
 
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Implements hook_install().
@@ -22,4 +24,27 @@ function oe_translation_install() {
       $form_display->save();
     }
   }
+}
+
+/**
+ * Creates the revision ID field on the TMGMT job item entity.
+ */
+function oe_translation_update_8001(&$sandbox) {
+  $field = BaseFieldDefinition::create('integer')
+    ->setLabel(new TranslatableMarkup('Item revision ID'))
+    ->setSetting('unsigned', TRUE);
+
+  \Drupal::entityDefinitionUpdateManager()
+    ->installFieldStorageDefinition('item_rid', 'tmgmt_job_item', 'oe_translation', $field);
+}
+
+/**
+ * Creates the Item bundle field on the TMGMT job item entity.
+ */
+function oe_translation_update_8002(&$sandbox) {
+  $field = BaseFieldDefinition::create('string')
+    ->setLabel(new TranslatableMarkup('Item bundle'));
+
+  \Drupal::entityDefinitionUpdateManager()
+    ->installFieldStorageDefinition('item_bundle', 'tmgmt_job_item', 'oe_translation', $field);
 }

--- a/oe_translation.module
+++ b/oe_translation.module
@@ -334,3 +334,34 @@ function oe_translation_tmgmt_translatable_fields_alter(ContentEntityInterface $
     unset($translatable_fields['moderation_state']);
   }
 }
+
+/**
+ * Implements hook_block_view_BASE_BLOCK_ID_alter() for the Page Header block.
+ */
+function oe_translation_block_view_oe_theme_helper_page_header_alter(array &$build, $block) {
+  $build['#pre_render'][] = 'oe_translation_page_header_pre_render';
+}
+
+/**
+ * Pre-render callback for the Page Header block alteration.
+ *
+ * This block is shipped by OpenEuropa Theme and we use this to remove the
+ * language switcher from the page header on the entity preview page.
+ *
+ * @param array $build
+ *   The built render array of the block.
+ *
+ * @return array
+ *   The built render array of the block.
+ */
+function oe_translation_page_header_pre_render(array $build): array {
+  if (\Drupal::service('current_route_match')->getRouteName() !== 'tmgmt_content.job_item_preview') {
+    return $build;
+  }
+
+  if (isset($build['content']['#language_switcher'])) {
+    unset($build['content']['#language_switcher']);
+  }
+
+  return $build;
+}

--- a/oe_translation.module
+++ b/oe_translation.module
@@ -319,3 +319,14 @@ function oe_translation_tmgmt_source_plugin_info_alter(&$definitions) {
     $definitions['content']['entity_translation_info'] = 'oe_translation.content_entity_source_translation_info';
   }
 }
+
+/**
+ * Implements hook_tmgmt_translatable_fields_alter().
+ */
+function oe_translation_tmgmt_translatable_fields_alter(ContentEntityInterface $entity, &$translatable_fields) {
+  // Prevent the moderation state to show up as a translatable field. It seems
+  // it does even if we mark the base field as non-translatable.
+  if (isset($translatable_fields['moderation_state'])) {
+    unset($translatable_fields['moderation_state']);
+  }
+}

--- a/oe_translation.module
+++ b/oe_translation.module
@@ -7,7 +7,10 @@
 
 declare(strict_types = 1);
 
+use Drupal\oe_translation\Entity\JobItem;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\oe_translation\AlterableTranslatorInterface;
 use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Access\AccessResult;
@@ -16,6 +19,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\oe_translation\ContentEntitySource;
 use Drupal\oe_translation\LocalTranslatorInterface;
 use Drupal\oe_translation\TranslationModerationHandler;
 use Drupal\tmgmt_content\DefaultFieldProcessor;
@@ -74,6 +78,12 @@ function oe_translation_form_tmgmt_job_item_edit_form_alter(&$form, FormStateInt
  */
 function oe_translation_entity_type_alter(array &$entity_types) {
   foreach ($entity_types as $entity_type_id => $entity_type) {
+    // Change the Job Item class with our own override.
+    if ($entity_type_id === 'tmgmt_job_item') {
+      $entity_type->setClass(JobItem::class);
+    }
+
+    // Change the moderation handler if set to our own override.
     if (!$entity_type->hasHandlerClass('moderation')) {
       continue;
     }
@@ -141,6 +151,26 @@ function oe_translation_preprocess_node(&$variables) {
   }
 
   $variables['page'] = TRUE;
+}
+
+/**
+ * Implements hook_entity_base_field_info().
+ */
+function oe_translation_entity_base_field_info(EntityTypeInterface $entity_type) {
+  if ($entity_type->id() === 'tmgmt_job_item') {
+    $fields = [];
+    // Add a field to the Job item to store the entity revision at the moment of
+    // creation.
+    $fields['item_rid'] = BaseFieldDefinition::create('integer')
+      ->setLabel(new TranslatableMarkup('Item revision ID'))
+      ->setSetting('unsigned', TRUE);
+    // Add a field to the Job item to store the entity bundle being translated.
+    // This is needed to be able to inspect field related info if the entity
+    // itself gets deleted.
+    $fields['item_bundle'] = BaseFieldDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('Item bundle'));
+    return $fields;
+  }
 }
 
 /**
@@ -246,4 +276,32 @@ function oe_translation_preprocess_local_translation_form_element_group(&$variab
   $table['#rows'] = $rows;
 
   $variables['element'] = $table;
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_presave() for the TMGMT job item.
+ */
+function oe_translation_tmgmt_job_item_presave(EntityInterface $entity) {
+  if (!$entity->isNew()) {
+    return;
+  }
+
+  // Whenever a new job item is created, store the item ID and bundle so that
+  // we can keep track of it later.
+  /** @var \Drupal\node\NodeInterface $node */
+  $node = \Drupal::entityTypeManager()->getStorage($entity->getItemType())->load($entity->getItemId());
+  $entity->set('item_rid', $node->getRevisionId());
+  $entity->set('item_bundle', $node->bundle());
+}
+
+/**
+ * Implements tmgmt_source_plugin_info_alter().
+ */
+function oe_translation_tmgmt_source_plugin_info_alter(&$definitions) {
+  if (isset($definitions['content'])) {
+    // Override the plugin class with ours.
+    $definitions['content']['class'] = ContentEntitySource::class;
+    // Set the service to be used for determining the entity translation info.
+    $definitions['content']['entity_translation_info'] = 'oe_translation.content_entity_source_translation_info';
+  }
 }

--- a/oe_translation.module
+++ b/oe_translation.module
@@ -303,9 +303,13 @@ function oe_translation_tmgmt_job_item_presave(EntityInterface $entity) {
     // We only support content entities for things like revisions and bundle.
     return;
   }
-  $entity->set('item_rid', $item->getRevisionId());
-  $entity->set('item_bundle', $item->bundle());
 
+  // We use the latest revision ID because we assume that the translation is
+  // already being started from the latest version of the content. Meaning
+  // that if we use the regular entity load it will load the latest published
+  // revision instead and we don't want that.
+  $entity->set('item_rid', $storage->getLatestRevisionId($entity->getItemId()));
+  $entity->set('item_bundle', $item->bundle());
 }
 
 /**

--- a/oe_translation.module
+++ b/oe_translation.module
@@ -7,6 +7,7 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\oe_translation\Entity\JobItem;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
@@ -286,12 +287,25 @@ function oe_translation_tmgmt_job_item_presave(EntityInterface $entity) {
     return;
   }
 
-  // Whenever a new job item is created, store the item ID and bundle so that
-  // we can keep track of it later.
-  /** @var \Drupal\node\NodeInterface $node */
-  $node = \Drupal::entityTypeManager()->getStorage($entity->getItemType())->load($entity->getItemId());
-  $entity->set('item_rid', $node->getRevisionId());
-  $entity->set('item_bundle', $node->bundle());
+  // Whenever a new job item is created, store the item revision ID and bundle
+  // so that we can keep track of them later.
+  try {
+    $storage = \Drupal::entityTypeManager()->getStorage($entity->getItemType());
+  }
+  catch (\Exception $exception) {
+    // This means the item type is not something we support here so we don't
+    // store this info.
+    return;
+  }
+
+  $item = $storage->load($entity->getItemId());
+  if (!$item instanceof ContentEntityInterface) {
+    // We only support content entities for things like revisions and bundle.
+    return;
+  }
+  $entity->set('item_rid', $item->getRevisionId());
+  $entity->set('item_bundle', $item->bundle());
+
 }
 
 /**

--- a/oe_translation.module
+++ b/oe_translation.module
@@ -280,39 +280,6 @@ function oe_translation_preprocess_local_translation_form_element_group(&$variab
 }
 
 /**
- * Implements hook_ENTITY_TYPE_presave() for the TMGMT job item.
- */
-function oe_translation_tmgmt_job_item_presave(EntityInterface $entity) {
-  if (!$entity->isNew()) {
-    return;
-  }
-
-  // Whenever a new job item is created, store the item revision ID and bundle
-  // so that we can keep track of them later.
-  try {
-    $storage = \Drupal::entityTypeManager()->getStorage($entity->getItemType());
-  }
-  catch (\Exception $exception) {
-    // This means the item type is not something we support here so we don't
-    // store this info.
-    return;
-  }
-
-  $item = $storage->load($entity->getItemId());
-  if (!$item instanceof ContentEntityInterface) {
-    // We only support content entities for things like revisions and bundle.
-    return;
-  }
-
-  // We use the latest revision ID because we assume that the translation is
-  // already being started from the latest version of the content. Meaning
-  // that if we use the regular entity load it will load the latest published
-  // revision instead and we don't want that.
-  $entity->set('item_rid', $storage->getLatestRevisionId($entity->getItemId()));
-  $entity->set('item_bundle', $item->bundle());
-}
-
-/**
  * Implements tmgmt_source_plugin_info_alter().
  */
 function oe_translation_tmgmt_source_plugin_info_alter(&$definitions) {

--- a/oe_translation.services.yml
+++ b/oe_translation.services.yml
@@ -1,6 +1,7 @@
 services:
   oe_translation.route_subscriber:
     class: Drupal\oe_translation\Routing\RouteSubscriber
+    arguments: ['@content_translation.manager']
     tags:
       - { name: event_subscriber }
   oe_translation.translation_provider_routes:
@@ -14,3 +15,7 @@ services:
     arguments: ['@entity_type.manager']
     tags:
       - { name: event_subscriber }
+  oe_translation.route_access_checker:
+    class: Drupal\oe_translation\Access\TranslationRouteAccess
+    tags:
+      - { name: access_check, applies_to: _access_oe_translation }

--- a/oe_translation.services.yml
+++ b/oe_translation.services.yml
@@ -6,3 +6,11 @@ services:
   oe_translation.translation_provider_routes:
     class: Drupal\oe_translation\Routing\TranslationProviderRoutes
     arguments: ['@plugin.manager.tmgmt.translator']
+  oe_translation.content_entity_source_translation_info:
+    class: Drupal\oe_translation\ContentEntitySourceTranslationInfo
+    arguments: ['@event_dispatcher']
+  oe_translation.content_entity_source_entity_subscriber.default:
+    class: Drupal\oe_translation\EventSubscriber\DefaultContentEntitySourceEntitySubscriber
+    arguments: ['@entity_type.manager']
+    tags:
+      - { name: event_subscriber }

--- a/src/Access/TranslationRouteAccess.php
+++ b/src/Access/TranslationRouteAccess.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_translation\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Route access handler for the content translation routes.
+ */
+class TranslationRouteAccess implements AccessInterface {
+
+  /**
+   * Access callback to prevent the regular Drupal translations.
+   *
+   * @param \Symfony\Component\Routing\Route $route
+   *   The route.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route match.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   * @param string $source
+   *   The source language.
+   * @param string $target
+   *   The target language.
+   * @param string $language
+   *   The current language.
+   * @param string $entity_type_id
+   *   The entity type ID of the entity being translated.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access.
+   */
+  public function access(Route $route, RouteMatchInterface $route_match, AccountInterface $account, string $source = NULL, string $target = NULL, string $language = NULL, string $entity_type_id = NULL): AccessResultInterface {
+    $operation = $route->getRequirement('_access_oe_translation');
+    // Nobody should ever create or edit translations using the regular core
+    // flow.
+    if (in_array($operation, ['create', 'update'])) {
+      return AccessResult::forbidden();
+    }
+
+    // We allow the deletion to happen still in case.
+    return AccessResult::neutral();
+  }
+
+}

--- a/src/ContentEntitySource.php
+++ b/src/ContentEntitySource.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_translation;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\tmgmt\JobItemInterface;
+use Drupal\tmgmt_content\Plugin\tmgmt\Source\ContentEntitySource as OriginalContentEntitySource;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * An override of the default ContentEntitySource plugin class.
+ */
+class ContentEntitySource extends OriginalContentEntitySource implements ContainerFactoryPluginInterface {
+
+  /**
+   * The content entity source translation info service.
+   *
+   * @var \Drupal\oe_translation\ContentEntitySourceTranslationInfo
+   */
+  protected $contentEntitySourceTranslationInfo;
+
+  /**
+   * ContentEntitySource constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration.
+   * @param string $plugin_id
+   *   The plugin ID.
+   * @param array $plugin_definition
+   *   The plugin definition.
+   * @param \Drupal\oe_translation\ContentEntitySourceTranslationInfo $contentEntitySourceTranslationInfo
+   *   The content entity source translation info service.
+   */
+  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, ContentEntitySourceTranslationInfo $contentEntitySourceTranslationInfo) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->contentEntitySourceTranslationInfo = $contentEntitySourceTranslationInfo;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('oe_translation.content_entity_source_translation_info')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Overriding the way the the entity is retrieved to allow others to determine
+   * which revision of the entity to work with for displaying data and saving.
+   */
+  protected function getEntity(JobItemInterface $job_item) {
+    return $this->contentEntitySourceTranslationInfo->getEntityFromJobItem($job_item);
+  }
+
+}

--- a/src/ContentEntitySourceTranslationInfo.php
+++ b/src/ContentEntitySourceTranslationInfo.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_translation;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\oe_translation\Event\ContentEntitySourceEntityEvent;
+use Drupal\tmgmt\JobItemInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Determines which revision of an entity the translation should go in.
+ */
+class ContentEntitySourceTranslationInfo implements EntitySourceTranslationInfoInterface {
+
+  /**
+   * The event dispatcher.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  protected $eventDispatcher;
+
+  /**
+   * ContentEntitySourceTranslationInfo constructor.
+   *
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *   The event dispatcher.
+   */
+  public function __construct(EventDispatcherInterface $eventDispatcher) {
+    $this->eventDispatcher = $eventDispatcher;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   *  This is the entity revision the translation should be saved into.
+   */
+  public function getEntityFromJobItem(JobItemInterface $jobItem): ?EntityInterface {
+    $event = new ContentEntitySourceEntityEvent($jobItem);
+    $this->eventDispatcher->dispatch(ContentEntitySourceEntityEvent::EVENT, $event);
+    return $event->getEntity();
+  }
+
+}

--- a/src/Controller/ContentTranslationController.php
+++ b/src/Controller/ContentTranslationController.php
@@ -61,6 +61,19 @@ class ContentTranslationController extends BaseContentTranslationController {
   public function overview(RouteMatchInterface $route_match, $entity_type_id = NULL): array {
     $build = parent::overview($route_match, $entity_type_id);
 
+    // Remove all the default operation links.
+    foreach ($build['content_translation_overview']['#rows'] as $row_key => &$row) {
+      end($row);
+      $pos = key($row);
+      if (!isset($row[$pos]['data']['#links'])) {
+        continue;
+      }
+
+      foreach ($row[$pos]['data']['#links'] as $link_key => $link) {
+        unset($build['content_translation_overview']['#rows'][$row_key][$pos]['data']['#links'][$link_key]);
+      }
+    }
+
     /** @var \Drupal\tmgmt\TranslatorInterface[] $translators */
     $translators = $this->entityTypeManager->getStorage('tmgmt_translator')->loadMultiple();
     foreach ($translators as $translator) {

--- a/src/Entity/JobItem.php
+++ b/src/Entity/JobItem.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_translation\Entity;
+
+use Drupal\Core\Entity\Exception\UndefinedLinkTemplateException;
+use Drupal\Core\Entity\TranslatableInterface;
+use Drupal\tmgmt\Entity\JobItem as OriginalJobItem;
+
+/**
+ * Override of the original TMGMT Job Item entity class.
+ */
+class JobItem extends OriginalJobItem {
+
+  /**
+   * {@inheritdoc}
+   *
+   * We need to override this method because it makes a hard assumption on
+   * the translation being saved on the latest loaded revision. And as such,
+   * if we save the translation on a previous revision, the message building
+   * logic breaks. So we need to fix this.
+   */
+  public function accepted($message = NULL, $variables = [], $type = 'status') {
+    if (!isset($message)) {
+      $message_info = $this->generateAcceptedMessage();
+      return parent::accepted($message_info['message'], $message_info['variables'], $type);
+    }
+
+    return parent::accepted($message, $variables, $type);
+  }
+
+  /**
+   * Creates the message for when a translation is accepted.
+   *
+   * We use the EntitySourceTranslationInfoInterface to determine the entity
+   * into which the translation was saved to generate the message.
+   *
+   * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+   * @SuppressWarnings(PHPMD.NPathComplexity)
+   */
+  protected function generateAcceptedMessage(): array {
+    $source_url = $this->getSourceUrl();
+
+    // Load the entity onto which the translation was supposedly saved.
+    $entity = NULL;
+    $translation = NULL;
+    $plugin_definition = $this->getSourcePlugin()->getPluginDefinition();
+
+    if (isset($plugin_definition['entity_translation_info'])) {
+      /** @var \Drupal\oe_translation\EntitySourceTranslationInfoInterface $translation_info */
+      $translation_info = \Drupal::service($plugin_definition['entity_translation_info']);
+      /** @var \Drupal\Core\Entity\TranslatableInterface $entity */
+      $entity = $translation_info->getEntityFromJobItem($this);
+      $translation = $entity->hasTranslation($this->getJob()->getTargetLangcode()) ? $entity->getTranslation($this->getJob()->getTargetLangcode()) : NULL;
+    }
+
+    if (!$entity instanceof TranslatableInterface || !$translation instanceof TranslatableInterface) {
+      return [
+        'message' => $source_url ? 'The translation for <a href=":source_url">@source</a> has been accepted.' : 'The translation for @source has been accepted.',
+        'variables' => $source_url ? [
+          ':source_url' => $source_url->toString(),
+          '@source' => $this->getSourceLabel(),
+        ] : ['@source' => $this->getSourceLabel()],
+      ];
+    }
+
+    try {
+      $translation_url = $translation->toUrl();
+    }
+    catch (UndefinedLinkTemplateException $e) {
+      $translation_url = NULL;
+    }
+
+    return [
+      'message' => $source_url && $translation_url ? 'The translation for <a href=":source_url">@source</a> has been accepted as <a href=":target_url">@target</a>.' : 'The translation for @source has been accepted as @target.',
+      'variables' => $translation_url ? [
+        ':source_url' => $source_url->toString(),
+        '@source' => $this->getSourceLabel(),
+        ':target_url' => $translation_url->toString(),
+        '@target' => $translation ? $translation->label() : $this->getSourceLabel(),
+      ] : ['@source' => $this->getSourceLabel(), '@target' => ($translation ? $translation->label() : $this->getSourceLabel())],
+    ];
+  }
+
+}

--- a/src/EntitySourceTranslationInfoInterface.php
+++ b/src/EntitySourceTranslationInfoInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_translation;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\tmgmt\JobItemInterface;
+
+/**
+ * Interface for source translation info services.
+ *
+ * Services of this kind determine where the translation of a given entity is
+ * saved. Used mostly for content entities which use revisions and we need to
+ * determine the revision to save the translation onto.
+ */
+interface EntitySourceTranslationInfoInterface {
+
+  /**
+   * Returns the entity from the job item.
+   *
+   * @param \Drupal\tmgmt\JobItemInterface $jobItem
+   *   The job item.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   The entity.
+   */
+  public function getEntityFromJobItem(JobItemInterface $jobItem): ?EntityInterface;
+
+}

--- a/src/Event/ContentEntitySourceEntityEvent.php
+++ b/src/Event/ContentEntitySourceEntityEvent.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_translation\Event;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\tmgmt\JobItemInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event class used for determining the entity to use in the content source.
+ *
+ * @see \Drupal\oe_translation\ContentEntitySource
+ */
+class ContentEntitySourceEntityEvent extends Event {
+
+  const EVENT = 'content_entity_source_entity_event';
+
+  /**
+   * The job item.
+   *
+   * @var \Drupal\tmgmt\JobItemInterface
+   */
+  protected $jobItem;
+
+  /**
+   * The entity.
+   *
+   * @var \Drupal\Core\Entity\ContentEntityInterface
+   */
+  protected $entity;
+
+  /**
+   * ContentEntitySourceEntityEvent constructor.
+   *
+   * @param \Drupal\tmgmt\JobItemInterface $jobItem
+   *   The job item.
+   */
+  public function __construct(JobItemInterface $jobItem) {
+    $this->jobItem = $jobItem;
+  }
+
+  /**
+   * Returns the entity.
+   *
+   * @return \Drupal\Core\Entity\ContentEntityInterface|null
+   *   The entity.
+   */
+  public function getEntity(): ?ContentEntityInterface {
+    return $this->entity;
+  }
+
+  /**
+   * Sets the entity.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface|null $entity
+   *   The entity.
+   */
+  public function setEntity(ContentEntityInterface $entity): void {
+    $this->entity = $entity;
+  }
+
+  /**
+   * Returns the job item.
+   *
+   * @return \Drupal\tmgmt\JobItemInterface
+   *   The job item.
+   */
+  public function getJobItem(): JobItemInterface {
+    return $this->jobItem;
+  }
+
+}

--- a/src/Event/TranslationAccessEvent.php
+++ b/src/Event/TranslationAccessEvent.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_translation\Event;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Language\Language;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event for altering the access to translate content.
+ */
+class TranslationAccessEvent extends Event {
+
+  const EVENT = 'translation_access_event';
+
+  /**
+   * The entity being translated.
+   *
+   * @var \Drupal\Core\Entity\ContentEntityInterface
+   */
+  protected $entity;
+
+  /**
+   * The source language.
+   *
+   * @var \Drupal\Core\Language\Language
+   */
+  protected $source;
+
+  /**
+   * The target language.
+   *
+   * @var \Drupal\Core\Language\Language
+   */
+  protected $target;
+
+  /**
+   * The account.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $account;
+
+  /**
+   * The translator plugin ID.
+   *
+   * @var string
+   */
+  protected $plugin;
+
+  /**
+   * The access result.
+   *
+   * @var \Drupal\Core\Access\AccessResultInterface
+   */
+  protected $access;
+
+  /**
+   * TranslationAccessEvent constructor.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity being translated.
+   * @param \Drupal\Core\Language\Language $source
+   *   The source language.
+   * @param \Drupal\Core\Language\Language $target
+   *   The target language.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The account.
+   * @param string $plugin
+   *   The translator plugin ID.
+   */
+  public function __construct(ContentEntityInterface $entity, Language $source, Language $target, AccountInterface $account, string $plugin) {
+    $this->entity = $entity;
+    $this->source = $source;
+    $this->target = $target;
+    $this->account = $account;
+    $this->plugin = $plugin;
+  }
+
+  /**
+   * Returns the entity.
+   *
+   * @return \Drupal\Core\Entity\ContentEntityInterface
+   *   The entity.
+   */
+  public function getEntity(): ContentEntityInterface {
+    return $this->entity;
+  }
+
+  /**
+   * Sets the entity.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity.
+   */
+  public function setEntity(ContentEntityInterface $entity): void {
+    $this->entity = $entity;
+  }
+
+  /**
+   * Returns the source language.
+   *
+   * @return \Drupal\Core\Language\Language
+   *   The source language.
+   */
+  public function getSource(): Language {
+    return $this->source;
+  }
+
+  /**
+   * Sets the source language.
+   *
+   * @param \Drupal\Core\Language\Language $source
+   *   The source language.
+   */
+  public function setSource(Language $source): void {
+    $this->source = $source;
+  }
+
+  /**
+   * Returns the target language.
+   *
+   * @return \Drupal\Core\Language\Language
+   *   The target language.
+   */
+  public function getTarget(): Language {
+    return $this->target;
+  }
+
+  /**
+   * Sets the target language..
+   *
+   * @param \Drupal\Core\Language\Language $target
+   *   The target language..
+   */
+  public function setTarget(Language $target): void {
+    $this->target = $target;
+  }
+
+  /**
+   * Returns the account.
+   *
+   * @return \Drupal\Core\Session\AccountInterface
+   *   The account.
+   */
+  public function getAccount(): AccountInterface {
+    return $this->account;
+  }
+
+  /**
+   * Sets the account.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The account.
+   */
+  public function setAccount(AccountInterface $account): void {
+    $this->account = $account;
+  }
+
+  /**
+   * Returns the translator plugin ID.
+   *
+   * @return string
+   *   The translator plugin ID.
+   */
+  public function getPlugin(): string {
+    return $this->plugin;
+  }
+
+  /**
+   * Sets the translator plugin ID.
+   *
+   * @param string $plugin
+   *   The translator plugin ID.
+   */
+  public function setPlugin(string $plugin): void {
+    $this->plugin = $plugin;
+  }
+
+  /**
+   * Returns the access result.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access.
+   */
+  public function getAccess(): AccessResultInterface {
+    return $this->access instanceof AccessResultInterface ? $this->access : AccessResult::neutral();
+  }
+
+  /**
+   * Sets the access result.
+   *
+   * @param \Drupal\Core\Access\AccessResultInterface $access
+   *   The access.
+   */
+  public function setAccess(AccessResultInterface $access): void {
+    $this->access = $access;
+  }
+
+}

--- a/src/EventSubscriber/DefaultContentEntitySourceEntitySubscriber.php
+++ b/src/EventSubscriber/DefaultContentEntitySourceEntitySubscriber.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_translation\EventSubscriber;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\oe_translation\Event\ContentEntitySourceEntityEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Default subscriber to the ContentEntitySourceEntityEvent event.
+ */
+class DefaultContentEntitySourceEntitySubscriber implements EventSubscriberInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * DefaultContentEntitySourceEntitySubscriber constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      // We set a low priority because this is the default way to get the
+      // entity.
+      ContentEntitySourceEntityEvent::EVENT => ['getEntity', -100],
+    ];
+  }
+
+  /**
+   * Sets the correct entity onto the event based on the Job item.
+   *
+   * By default, we try to load the same revision as was used at the moment
+   * of creating the translation job item. However, if one is not set for any
+   * reason, we fall back to the default (latest) revision that is loaded.
+   *
+   * @param \Drupal\oe_translation\Event\ContentEntitySourceEntityEvent $event
+   *   The event.
+   */
+  public function getEntity(ContentEntitySourceEntityEvent $event): void {
+    $job_item = $event->getJobItem();
+    if (!$job_item->hasField('item_rid') || $job_item->get('item_rid')->isEmpty()) {
+      /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+      $entity = $this->entityTypeManager->getStorage($job_item->getItemType())->load($job_item->getItemId());
+      // Fallback to the default TMGMT behaviour if we can't determine the
+      // revision ID.
+      if ($entity) {
+        // The entity could have been deleted.
+        $event->setEntity($entity);
+      }
+
+      return;
+    }
+
+    // Otherwise, use the revision.
+    /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+    $entity = $this->entityTypeManager->getStorage($job_item->getItemType())->loadRevision($job_item->get('item_rid')->value);
+    if (!$entity instanceof ContentEntityInterface) {
+      /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+      $entity = $this->entityTypeManager->getStorage($job_item->getItemType())->load($job_item->getItemId());
+    }
+
+    if ($entity) {
+      // The entity could have been deleted.
+      $event->setEntity($entity);
+    }
+  }
+
+}

--- a/src/Plugin/tmgmt/Translator/PermissionTranslator.php
+++ b/src/Plugin/tmgmt/Translator/PermissionTranslator.php
@@ -15,7 +15,6 @@ use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
@@ -86,13 +85,6 @@ class PermissionTranslator extends TranslatorPluginBase implements ContinuousTra
   protected $entityTypeManager;
 
   /**
-   * The form builder.
-   *
-   * @var \Drupal\Core\Form\FormBuilderInterface
-   */
-  protected $formBuilder;
-
-  /**
    * The current request.
    *
    * @var \Symfony\Component\HttpFoundation\Request
@@ -122,8 +114,6 @@ class PermissionTranslator extends TranslatorPluginBase implements ContinuousTra
    * @param \Drupal\Core\Access\AccessManagerInterface $access_manager
    *   The access manager.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Form\FormBuilderInterface $form_builder
    *   The form builder.
    * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
    *   The request stack.
@@ -132,13 +122,12 @@ class PermissionTranslator extends TranslatorPluginBase implements ContinuousTra
    *
    * @SuppressWarnings(PHPMD.ExcessiveParameterList)
    */
-  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, AccountProxyInterface $current_user, LanguageManagerInterface $language_manager, AccessManagerInterface $access_manager, EntityTypeManagerInterface $entity_type_manager, FormBuilderInterface $form_builder, RequestStack $request_stack, EntityFieldManagerInterface $entity_field_manager) {
+  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, AccountProxyInterface $current_user, LanguageManagerInterface $language_manager, AccessManagerInterface $access_manager, EntityTypeManagerInterface $entity_type_manager, RequestStack $request_stack, EntityFieldManagerInterface $entity_field_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->currentUser = $current_user;
     $this->languageManager = $language_manager;
     $this->accessManager = $access_manager;
     $this->entityTypeManager = $entity_type_manager;
-    $this->formBuilder = $form_builder;
     $this->request = $request_stack->getCurrentRequest();
     $this->entityFieldManager = $entity_field_manager;
   }
@@ -155,7 +144,6 @@ class PermissionTranslator extends TranslatorPluginBase implements ContinuousTra
       $container->get('language_manager'),
       $container->get('access_manager'),
       $container->get('entity_type.manager'),
-      $container->get('form_builder'),
       $container->get('request_stack'),
       $container->get('entity_field.manager')
     );
@@ -440,12 +428,6 @@ class PermissionTranslator extends TranslatorPluginBase implements ContinuousTra
           'title' => $this->t('Translate locally'),
         ];
       }
-    }
-
-    // Wrap the form with the multiple translations request form.
-    // @see \Drupal\tmgmt_content\Controller\ContentTranslationControllerOverride
-    if ($this->entityTypeManager->getAccessControlHandler('tmgmt_job')->createAccess()) {
-      $build = $this->formBuilder->getForm('Drupal\tmgmt_content\Form\ContentTranslateForm', $build);
     }
   }
 

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_translation\Routing;
 
+use Drupal\content_translation\ContentTranslationManagerInterface;
 use Drupal\Core\Routing\RouteSubscriberBase;
 use Drupal\Core\Routing\RoutingEvents;
 use Symfony\Component\Routing\RouteCollection;
@@ -12,6 +13,23 @@ use Symfony\Component\Routing\RouteCollection;
  * Wraps translation routes.
  */
 class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * The content translation manager.
+   *
+   * @var \Drupal\content_translation\ContentTranslationManagerInterface
+   */
+  protected $contentTranslationManager;
+
+  /**
+   * Constructs a ContentTranslationRouteSubscriber object.
+   *
+   * @param \Drupal\content_translation\ContentTranslationManagerInterface $content_translation_manager
+   *   The content translation manager.
+   */
+  public function __construct(ContentTranslationManagerInterface $content_translation_manager) {
+    $this->contentTranslationManager = $content_translation_manager;
+  }
 
   /**
    * {@inheritdoc}
@@ -37,6 +55,31 @@ class RouteSubscriber extends RouteSubscriberBase {
       if ($route->getDefault('_controller') == '\Drupal\tmgmt_content\Controller\ContentTranslationPreviewController::preview') {
         $route->setDefault('_controller', '\Drupal\oe_translation\Controller\ContentPreviewController::preview');
         $route->setDefault('_title_callback', '\Drupal\oe_translation\Controller\ContentPreviewController::title');
+      }
+
+      // Alter the routes to provide a custom access check to the regular
+      // Drupal translation management routes.
+      foreach ($this->contentTranslationManager->getSupportedEntityTypes() as $entity_type_id => $entity_type) {
+        if ($entity_type->hasLinkTemplate('drupal:content-translation-add')) {
+          $route_name = "entity.$entity_type_id.content_translation_add";
+          $route = $collection->get($route_name);
+          $route->setRequirement('_access_oe_translation', 'create');
+          $collection->add($route_name, $route);
+        }
+
+        if ($entity_type->hasLinkTemplate('drupal:content-translation-edit')) {
+          $route_name = "entity.$entity_type_id.content_translation_edit";
+          $route = $collection->get($route_name);
+          $route->setRequirement('_access_oe_translation', 'update');
+          $collection->add($route_name, $route);
+        }
+
+        if ($entity_type->hasLinkTemplate('drupal:content-translation-delete')) {
+          $route_name = "entity.$entity_type_id.content_translation_delete";
+          $route = $collection->get($route_name);
+          $route->setRequirement('_access_oe_translation', 'delete');
+          $collection->add($route_name, $route);
+        }
       }
     }
   }

--- a/tests/Functional/ExtensibilityTest.php
+++ b/tests/Functional/ExtensibilityTest.php
@@ -6,7 +6,6 @@ namespace Drupal\Tests\oe_translation\Functional;
 
 use Drupal\Core\Routing\CurrentRouteMatch;
 use Drupal\Core\Url;
-use Drupal\Tests\BrowserTestBase;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -14,56 +13,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 /**
  * Tests that we are allowing Translator plugins to make alterations.
  */
-class ExtensibilityTest extends BrowserTestBase {
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * {@inheritdoc}
-   */
-  protected static $modules = [
-    'tmgmt',
-    'tmgmt_local',
-    'tmgmt_content',
-    'oe_multilingual',
-    'node',
-    'toolbar',
-    'content_translation',
-    'user',
-    'field',
-    'text',
-    'options',
-    'oe_translation',
-    'oe_translation_test',
-  ];
-
-  /**
-   * {@inheritdoc}
-   */
-  public function setUp() {
-    parent::setUp();
-
-    $this->entityTypeManager = $this->container->get('entity_type.manager');
-
-    $this->entityTypeManager->getStorage('node_type')->create([
-      'name' => 'Page',
-      'type' => 'page',
-    ])->save();
-
-    $this->container->get('content_translation.manager')->setEnabled('node', 'page', TRUE);
-    $this->container->get('router.builder')->rebuild();
-
-    /** @var \Drupal\user\RoleInterface $role */
-    $role = $this->entityTypeManager->getStorage('user_role')->load('translator');
-    $user = $this->drupalCreateUser($role->getPermissions());
-
-    $this->drupalLogin($user);
-  }
+class ExtensibilityTest extends TranslationTestBase {
 
   /**
    * Tests that the plugins can alter pages and forms, and propose routes.

--- a/tests/Functional/TranslationRevisionTest.php
+++ b/tests/Functional/TranslationRevisionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_translation\Functional;
+
+use Drupal\Core\Url;
+
+/**
+ * Tests that translations are saved in the correct revision.
+ */
+class TranslationRevisionTest extends TranslationTestBase {
+
+  /**
+   * Tests that translations are stored in the revision they started from.
+   */
+  public function testTranslationRevisionIsKept() {
+    /** @var \Drupal\node\NodeStorageInterface $node_storage */
+    $node_storage = $this->entityTypeManager->getStorage('node');
+
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $node_storage->create([
+      'type' => 'page',
+      'title' => 'My node',
+    ]);
+    $node->save();
+
+    // Create a local translation task.
+    $this->drupalGet(Url::fromRoute('oe_translation.permission_translator.create_local_task', [
+      'entity' => $node->id(),
+      'source' => 'en',
+      'target' => 'fr',
+      'entity_type' => 'node',
+    ]));
+    $this->assertSession()->elementContains('css', '#edit-title0value-translation', 'My node');
+
+    // At this point the job item and local task have been created for the
+    // translation and they should reference the revision ID of the node.
+    $job_items = $this->entityTypeManager->getStorage('tmgmt_job_item')->loadByProperties(['item_rid' => $node->getRevisionId()]);
+    $this->assertCount(1, $job_items);
+
+    // Save a new revision of the node before finalizing the translation and
+    // check we have two revisions in total.
+    $node->set('title', 'My node updated');
+    $node->setNewRevision();
+    $node->save();
+    $revisions = $node_storage->revisionIds($node);
+    $this->assertCount(2, $revisions);
+
+    // Finalize the translation and ensure the translation was set on the
+    // first node revision, not the subsequent one.
+    $values = [
+      'title|0|value[translation]' => 'My node FR',
+    ];
+    // It should be the first local task item created so we use the ID 1.
+    $url = Url::fromRoute('entity.tmgmt_local_task_item.canonical', ['tmgmt_local_task_item' => 1]);
+    $this->drupalPostForm($url, $values, t('Save'));
+
+    // The node title is that of the original revision, not the new one created.
+    $this->assertSession()->pageTextContains('The translation for My node has been saved as completed.');
+    $node_storage->resetCache();
+    $revision_ids = $node_storage->revisionIds($node);
+    // The revisions are sorted by revision ID ASC.
+    /** @var \Drupal\Core\Entity\TranslatableInterface $first_revision */
+    $first_revision = $node_storage->loadRevision($revision_ids[0]);
+    $this->assertTrue($first_revision->hasTranslation('fr'));
+    $this->assertEquals('My node FR', $first_revision->getTranslation('fr')->label());
+    /** @var \Drupal\Core\Entity\TranslatableInterface $second_revision */
+    $second_revision = $node_storage->loadRevision($revision_ids[1]);
+    $this->assertFalse($second_revision->hasTranslation('fr'));
+  }
+
+}

--- a/tests/Functional/TranslationTestBase.php
+++ b/tests/Functional/TranslationTestBase.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_translation\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Base class for functional tests.
+ */
+class TranslationTestBase extends BrowserTestBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'tmgmt',
+    'tmgmt_local',
+    'tmgmt_content',
+    'oe_multilingual',
+    'node',
+    'toolbar',
+    'content_translation',
+    'user',
+    'field',
+    'text',
+    'options',
+    'oe_translation',
+    'oe_translation_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->entityTypeManager = $this->container->get('entity_type.manager');
+
+    $this->entityTypeManager->getStorage('node_type')->create([
+      'name' => 'Page',
+      'type' => 'page',
+    ])->save();
+
+    $this->container->get('content_translation.manager')->setEnabled('node', 'page', TRUE);
+    $this->container->get('router.builder')->rebuild();
+
+    /** @var \Drupal\user\RoleInterface $role */
+    $role = $this->entityTypeManager->getStorage('user_role')->load('translator');
+    $user = $this->drupalCreateUser($role->getPermissions());
+
+    $this->drupalLogin($user);
+  }
+
+}

--- a/tests/Kernel/LinkFieldProcessorTest.php
+++ b/tests/Kernel/LinkFieldProcessorTest.php
@@ -29,6 +29,7 @@ class LinkFieldProcessorTest extends KernelTestBase {
     'language',
     'oe_multilingual',
     'tmgmt',
+    'content_translation',
     'oe_translation',
     'views',
   ];

--- a/tests/Kernel/TranslationsRevisionTest.php
+++ b/tests/Kernel/TranslationsRevisionTest.php
@@ -36,6 +36,7 @@ class TranslationsRevisionTest extends KernelTestBase {
     'language',
     'oe_multilingual',
     'content_moderation',
+    'content_translation',
     'views',
   ];
 


### PR DESCRIPTION
A few things happen in the PR:

* We create some base fields on the job item entity so that we can store the bundle and revision ID of the entity that is being translated at the moment of the request
* We override the JobItem entity class to fix a hardcoded assumption when generating an accepted message
* We override the TMGMT content entity source class to determine which revision of the entity we should use to store the translation onto when it comes back. An `EntitySourceTranslationInfoInterface` is used for this which dispatches an event that a subscriber listens to to provide the info. ANd by default, we use the same revision as the one from which the translation was requested.
* We hide the language switcher in the page header on the preview pages
* We deny access to create/edit regular Drupal translations
* Some other adjacent fixes