### PR TITLE
OPENEUROPA-2173: Deny access to checkout form if no jobs are in the queue

### DIFF
--- a/modules/oe_translation_poetry/oe_translation_poetry.routing.yml
+++ b/modules/oe_translation_poetry/oe_translation_poetry.routing.yml
@@ -5,4 +5,4 @@ oe_translation_poetry.job_queue_checkout:
     _title: 'Send request to DG Translation'
   requirements:
     _permission: 'translate any entity'
-    _custom_access: Drupal\oe_translation_poetry\Form\NewTranslationRequestForm::access
+    _custom_access: oe_translation_poetry.job_queue::access

--- a/modules/oe_translation_poetry/oe_translation_poetry.routing.yml
+++ b/modules/oe_translation_poetry/oe_translation_poetry.routing.yml
@@ -5,3 +5,4 @@ oe_translation_poetry.job_queue_checkout:
     _title: 'Send request to DG Translation'
   requirements:
     _permission: 'translate any entity'
+    _custom_access: Drupal\oe_translation_poetry\Form\NewTranslationRequestForm::access

--- a/modules/oe_translation_poetry/src/Form/PoetryCheckoutFormBase.php
+++ b/modules/oe_translation_poetry/src/Form/PoetryCheckoutFormBase.php
@@ -5,12 +5,10 @@ declare(strict_types = 1);
 namespace Drupal\oe_translation_poetry\Form;
 
 use Drupal\Component\Render\FormattableMarkup;
-use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Messenger\MessengerInterface;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\oe_translation_poetry\Poetry;
 use Drupal\oe_translation_poetry\PoetryJobQueue;
@@ -419,23 +417,6 @@ abstract class PoetryCheckoutFormBase extends FormBase {
 
     $message = new FormattableMarkup('The DGT request with the following jobs has been rejected upon submission: @jobs The messages have been saved in the jobs.', ['@jobs' => implode(', ', $job_ids)]);
     throw new \Exception($message->__toString());
-  }
-
-  /**
-   * Checks access for a checkout form.
-   *
-   * @param \Drupal\Core\Session\AccountInterface $account
-   *   Run access checks for this account.
-   *
-   * @return \Drupal\Core\Access\AccessResultInterface
-   *   The access result.
-   */
-  public function access(AccountInterface $account) {
-    $current_jobs = $this->queue->getAllJobs();
-    // Deny access if there are no jobs in the queue.
-    return AccessResult::allowedIf(!empty($current_jobs))
-      ->cachePerUser()
-      ->addCacheTags(['tmgmt_job_list']);
   }
 
 }

--- a/modules/oe_translation_poetry/src/Form/PoetryCheckoutFormBase.php
+++ b/modules/oe_translation_poetry/src/Form/PoetryCheckoutFormBase.php
@@ -433,7 +433,9 @@ abstract class PoetryCheckoutFormBase extends FormBase {
   public function access(AccountInterface $account) {
     $current_jobs = $this->queue->getAllJobs();
     // Deny access if there are no jobs in the queue.
-    return AccessResult::allowedIf(!empty($current_jobs));
+    return AccessResult::allowedIf(!empty($current_jobs))
+      ->cachePerUser()
+      ->addCacheTags(['tmgmt_job_list']);
   }
 
 }

--- a/modules/oe_translation_poetry/src/Form/PoetryCheckoutFormBase.php
+++ b/modules/oe_translation_poetry/src/Form/PoetryCheckoutFormBase.php
@@ -5,10 +5,12 @@ declare(strict_types = 1);
 namespace Drupal\oe_translation_poetry\Form;
 
 use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\oe_translation_poetry\Poetry;
 use Drupal\oe_translation_poetry\PoetryJobQueue;
@@ -417,6 +419,21 @@ abstract class PoetryCheckoutFormBase extends FormBase {
 
     $message = new FormattableMarkup('The DGT request with the following jobs has been rejected upon submission: @jobs The messages have been saved in the jobs.', ['@jobs' => implode(', ', $job_ids)]);
     throw new \Exception($message->__toString());
+  }
+
+  /**
+   * Checks access for a checkout form.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Run access checks for this account.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(AccountInterface $account) {
+    $current_jobs = $this->queue->getAllJobs();
+    // Deny access if there are no jobs in the queue.
+    return AccessResult::allowedIf(!empty($current_jobs));
   }
 
 }

--- a/modules/oe_translation_poetry/src/PoetryJobQueue.php
+++ b/modules/oe_translation_poetry/src/PoetryJobQueue.php
@@ -4,8 +4,10 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_translation_poetry;
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
 use Drupal\tmgmt\JobInterface;
@@ -131,6 +133,21 @@ class PoetryJobQueue {
    */
   public function reset(): void {
     $this->store->delete('queue');
+  }
+
+  /**
+   * Access handler for routes that depend on the job queue.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The current user.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   The access result.
+   */
+  public function access(AccountInterface $account) {
+    return AccessResult::allowedIf(!empty($this->getAllJobs()))
+      ->cachePerUser()
+      ->addCacheTags(['tmgmt_job_list']);
   }
 
   /**

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_translation_poetry\Functional;
 
+use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Drupal\oe_translation_poetry_mock\PoetryMock;
 use Drupal\Tests\oe_translation\Functional\TranslationTestBase;
@@ -46,6 +47,26 @@ class PoetryTranslationRequestTest extends TranslationTestBase {
     $this->container->set('oe_translation_poetry_mock.fixture_generator', NULL);
 
     $this->jobStorage = $this->entityTypeManager->getStorage('tmgmt_job');
+  }
+
+  /**
+   * Check access permission to the checkout form.
+   */
+  public function checkoutFormAccess(): void {
+    /** @var \Drupal\node\NodeStorageInterface $node_storage */
+    $node_storage = $this->entityTypeManager->getStorage('node');
+
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $node_storage->create([
+      'type' => 'page',
+      'title' => 'My first node',
+    ]);
+    $node->save();
+
+    $this->drupalGet(Url::fromRoute('oe_translation_poetry.job_queue_checkout'));
+    $this->assertSession()->statusCodeEquals(403);
+    $this->createInitialTranslationJobs($node, ['bg', 'cs']);
+    $this->assertSession()->statusCodeEquals(200);
   }
 
   /**

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
@@ -50,26 +50,6 @@ class PoetryTranslationRequestTest extends TranslationTestBase {
   }
 
   /**
-   * Check access permission to the checkout form.
-   */
-  public function checkoutFormAccess(): void {
-    /** @var \Drupal\node\NodeStorageInterface $node_storage */
-    $node_storage = $this->entityTypeManager->getStorage('node');
-
-    /** @var \Drupal\node\NodeInterface $node */
-    $node = $node_storage->create([
-      'type' => 'page',
-      'title' => 'My first node',
-    ]);
-    $node->save();
-
-    $this->drupalGet(Url::fromRoute('oe_translation_poetry.job_queue_checkout'));
-    $this->assertSession()->statusCodeEquals(403);
-    $this->createInitialTranslationJobs($node, ['bg', 'cs']);
-    $this->assertSession()->statusCodeEquals(200);
-  }
-
-  /**
    * Tests new translation requests.
    */
   public function testNewTranslationRequest(): void {
@@ -83,8 +63,13 @@ class PoetryTranslationRequestTest extends TranslationTestBase {
     ]);
     $node->save();
 
+    // Assert we can't access the checkout route without jobs in the queue.
+    $this->drupalGet(Url::fromRoute('oe_translation_poetry.job_queue_checkout'));
+    $this->assertSession()->statusCodeEquals(403);
+
     // Select some languages to translate.
     $this->createInitialTranslationJobs($node, ['bg', 'cs']);
+    $this->assertSession()->statusCodeEquals(200);
     // Check that two jobs have been created for the two languages and that
     // their status is unprocessed.
     /** @var \Drupal\tmgmt\JobInterface[] $jobs */


### PR DESCRIPTION
## OPENEUROPA-2173
### Description

Deny access to checkout form if no jobs are in the queue

### Change log

- Added: Access check for checkout form
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

