### PR TITLE
OPENEUROPA-2172: Implement a custom logger channel factory to instantiate our custom channel class.

### DIFF
--- a/modules/oe_translation_poetry/oe_translation_poetry.services.yml
+++ b/modules/oe_translation_poetry/oe_translation_poetry.services.yml
@@ -1,14 +1,16 @@
 services:
   oe_translation_poetry.client_factory:
     class: Drupal\oe_translation_poetry\PoetryFactory
-    arguments: ['@entity_type.manager', '@config.factory', '@oe_translation_poetry.logger.channel.poetry', '@logger.dblog', '@state', '@database', '@request_stack']
+    arguments: ['@entity_type.manager', '@config.factory', '@oe_translation.logger.factory', '@state', '@database', '@request_stack']
   oe_translation_poetry.client.default:
     class: Drupal\oe_translation_poetry\Poetry
     factory: oe_translation_poetry.client_factory:get
     arguments: ['poetry']
-  oe_translation_poetry.logger.channel.poetry:
-    class: Drupal\oe_translation_poetry\Logger\PoetryLoggerChannel
-    arguments: ['poetry']
+  oe_translation.logger.factory:
+    class: Drupal\oe_translation_poetry\Logger\PoetryLoggerChannelFactory
+    parent: container.trait
+    tags:
+      - { name: service_collector, tag: logger, call: addLogger }
   oe_translation_poetry.job_queue:
     class: Drupal\oe_translation_poetry\PoetryJobQueue
     arguments: ['@tempstore.private', '@entity_type.manager']

--- a/modules/oe_translation_poetry/src/Logger/PoetryLoggerChannel.php
+++ b/modules/oe_translation_poetry/src/Logger/PoetryLoggerChannel.php
@@ -17,9 +17,6 @@ use EC\Poetry\Events\ParseResponseEvent;
 /**
  * Custom logger channel for Poetry events.
  *
- * This is instantiated as a service inside the Poetry service and not using
- * the regular factory. It is meant to use only the DB Logger for the moment.
- *
  * @see \Drupal\oe_translation_poetry\Poetry
  */
 class PoetryLoggerChannel extends LoggerChannel {

--- a/modules/oe_translation_poetry/src/Logger/PoetryLoggerChannelFactory.php
+++ b/modules/oe_translation_poetry/src/Logger/PoetryLoggerChannelFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\oe_translation_poetry\Logger;
+
+use Drupal\Core\Logger\LoggerChannelFactory;
+
+/**
+ * Custom logger channel factory for the Poetry client.
+ *
+ * Since we need a custom logger channel class to process Poetry messages
+ * we also need a custom logger channel factory that will instantiate said
+ * custom logger when prompted.
+ *
+ * @see \Drupal\oe_translation_poetry\Poetry
+ * @see \Drupal\oe_translation_poetry\Logger\PoetryLoggerChannel
+ */
+class PoetryLoggerChannelFactory extends LoggerChannelFactory {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get($channel) {
+    if ($channel !== 'poetry') {
+      return parent::get($channel);
+    }
+
+    if (!isset($this->channels[$channel])) {
+      $instance = new PoetryLoggerChannel($channel);
+
+      // If we have a container set the request_stack and current_user services
+      // on the channel. It is up to the channel to determine if there is a
+      // current request.
+      if ($this->container) {
+        $instance->setRequestStack($this->container->get('request_stack'));
+        $instance->setCurrentUser($this->container->get('current_user'));
+      }
+
+      // Pass the loggers to the channel.
+      $instance->setLoggers($this->loggers);
+      $this->channels[$channel] = $instance;
+    }
+
+    return $this->channels[$channel];
+  }
+
+}

--- a/modules/oe_translation_poetry/src/Logger/PoetryLoggerChannelFactory.php
+++ b/modules/oe_translation_poetry/src/Logger/PoetryLoggerChannelFactory.php
@@ -20,10 +20,6 @@ class PoetryLoggerChannelFactory extends LoggerChannelFactory {
    * {@inheritdoc}
    */
   public function get($channel) {
-    if ($channel !== 'poetry') {
-      return parent::get($channel);
-    }
-
     if (!isset($this->channels[$channel])) {
       $instance = new PoetryLoggerChannel($channel);
 

--- a/modules/oe_translation_poetry/src/Logger/PoetryLoggerChannelFactory.php
+++ b/modules/oe_translation_poetry/src/Logger/PoetryLoggerChannelFactory.php
@@ -9,7 +9,10 @@ use Drupal\Core\Logger\LoggerChannelFactory;
  *
  * Since we need a custom logger channel class to process Poetry messages
  * we also need a custom logger channel factory that will instantiate said
- * custom logger when prompted.
+ * custom logger when needed.
+ *
+ * We are extending from the core channel factory to inherit the service
+ * collection of the logger implementations.
  *
  * @see \Drupal\oe_translation_poetry\Poetry
  * @see \Drupal\oe_translation_poetry\Logger\PoetryLoggerChannel

--- a/modules/oe_translation_poetry/src/Poetry.php
+++ b/modules/oe_translation_poetry/src/Poetry.php
@@ -6,7 +6,7 @@ namespace Drupal\oe_translation_poetry;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
-use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Site\Settings;
@@ -14,7 +14,6 @@ use Drupal\Core\State\State;
 use Drupal\tmgmt\Entity\Job;
 use EC\Poetry\Messages\Components\Identifier;
 use EC\Poetry\Poetry as PoetryLibrary;
-use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -90,10 +89,8 @@ class Poetry {
    *   The settings provided by the translator config.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   The config factory.
-   * @param \Drupal\Core\Logger\LoggerChannelInterface $loggerChannel
-   *   The logger channel.
-   * @param \Psr\Log\LoggerInterface $logger
-   *   The logger.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
+   *   The logger channel factory.
    * @param \Drupal\Core\State\State $state
    *   The state.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
@@ -103,14 +100,13 @@ class Poetry {
    * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
    *   The request stack.
    */
-  public function __construct(array $settings, ConfigFactoryInterface $configFactory, LoggerChannelInterface $loggerChannel, LoggerInterface $logger, State $state, EntityTypeManagerInterface $entityTypeManager, Connection $database, RequestStack $requestStack) {
+  public function __construct(array $settings, ConfigFactoryInterface $configFactory, LoggerChannelFactoryInterface $loggerFactory, State $state, EntityTypeManagerInterface $entityTypeManager, Connection $database, RequestStack $requestStack) {
     $this->translatorSettings = $settings;
     $this->state = $state;
     $this->entityTypeManager = $entityTypeManager;
     $this->database = $database;
     // @todo improve this in case we need alternative logging mechanisms.
-    $this->loggerChannel = $loggerChannel;
-    $this->loggerChannel->addLogger($logger);
+    $this->loggerChannel = $loggerFactory->get('poetry');
     $this->requestStack = $requestStack;
     $this->configFactory = $configFactory;
 

--- a/modules/oe_translation_poetry/src/Poetry.php
+++ b/modules/oe_translation_poetry/src/Poetry.php
@@ -6,9 +6,9 @@ namespace Drupal\oe_translation_poetry;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Site\Settings;
 use Drupal\Core\State\State;
 use Drupal\tmgmt\Entity\Job;
@@ -89,8 +89,8 @@ class Poetry {
    *   The settings provided by the translator config.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   The config factory.
-   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
-   *   The logger channel factory.
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $loggerChannel
+   *   The logger channel.
    * @param \Drupal\Core\State\State $state
    *   The state.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
@@ -100,13 +100,13 @@ class Poetry {
    * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
    *   The request stack.
    */
-  public function __construct(array $settings, ConfigFactoryInterface $configFactory, LoggerChannelFactoryInterface $loggerFactory, State $state, EntityTypeManagerInterface $entityTypeManager, Connection $database, RequestStack $requestStack) {
+  public function __construct(array $settings, ConfigFactoryInterface $configFactory, LoggerChannelInterface $loggerChannel, State $state, EntityTypeManagerInterface $entityTypeManager, Connection $database, RequestStack $requestStack) {
     $this->translatorSettings = $settings;
     $this->state = $state;
     $this->entityTypeManager = $entityTypeManager;
     $this->database = $database;
     // @todo improve this in case we need alternative logging mechanisms.
-    $this->loggerChannel = $loggerFactory->get('poetry');
+    $this->loggerChannel = $loggerChannel;
     $this->requestStack = $requestStack;
     $this->configFactory = $configFactory;
 

--- a/modules/oe_translation_poetry/src/Poetry.php
+++ b/modules/oe_translation_poetry/src/Poetry.php
@@ -105,7 +105,6 @@ class Poetry {
     $this->state = $state;
     $this->entityTypeManager = $entityTypeManager;
     $this->database = $database;
-    // @todo improve this in case we need alternative logging mechanisms.
     $this->loggerChannel = $loggerChannel;
     $this->requestStack = $requestStack;
     $this->configFactory = $configFactory;

--- a/modules/oe_translation_poetry/src/PoetryFactory.php
+++ b/modules/oe_translation_poetry/src/PoetryFactory.php
@@ -7,10 +7,9 @@ namespace Drupal\oe_translation_poetry;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\State\State;
 use Drupal\tmgmt\TranslatorInterface;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -33,18 +32,11 @@ class PoetryFactory {
   protected $configFactory;
 
   /**
-   * The logger channel.
+   * The logger channel factory.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
    */
-  protected $loggerChannel;
-
-  /**
-   * The DB logger.
-   *
-   * @var \Psr\Log\LoggerInterface
-   */
-  protected $logger;
+  protected $loggerFactory;
 
   /**
    * The state.
@@ -74,10 +66,8 @@ class PoetryFactory {
    *   The entity type manager.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   The config factory.
-   * @param \Drupal\Core\Logger\LoggerChannelInterface $loggerChannel
-   *   The logger channel.
-   * @param \Psr\Log\LoggerInterface $logger
-   *   The logger.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
+   *   The logger channel factory.
    * @param \Drupal\Core\State\State $state
    *   The Drupal state.
    * @param \Drupal\Core\Database\Connection $database
@@ -85,11 +75,10 @@ class PoetryFactory {
    * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
    *   The request stack.
    */
-  public function __construct(EntityTypeManagerInterface $entityTypeManager, ConfigFactoryInterface $configFactory, LoggerChannelInterface $loggerChannel, LoggerInterface $logger, State $state, Connection $database, RequestStack $requestStack) {
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, ConfigFactoryInterface $configFactory, LoggerChannelFactoryInterface $loggerFactory, State $state, Connection $database, RequestStack $requestStack) {
     $this->entityTypeManager = $entityTypeManager;
     $this->configFactory = $configFactory;
-    $this->loggerChannel = $loggerChannel;
-    $this->logger = $logger;
+    $this->loggerFactory = $loggerFactory;
     $this->state = $state;
     $this->database = $database;
     $this->requestStack = $requestStack;
@@ -111,7 +100,7 @@ class PoetryFactory {
       $settings = $entity->get('settings');
     }
 
-    return new Poetry($settings, $this->configFactory, $this->loggerChannel, $this->logger, $this->state, $this->entityTypeManager, $this->database, $this->requestStack);
+    return new Poetry($settings, $this->configFactory, $this->loggerFactory, $this->state, $this->entityTypeManager, $this->database, $this->requestStack);
   }
 
 }

--- a/modules/oe_translation_poetry/src/PoetryFactory.php
+++ b/modules/oe_translation_poetry/src/PoetryFactory.php
@@ -100,7 +100,7 @@ class PoetryFactory {
       $settings = $entity->get('settings');
     }
 
-    return new Poetry($settings, $this->configFactory, $this->loggerFactory, $this->state, $this->entityTypeManager, $this->database, $this->requestStack);
+    return new Poetry($settings, $this->configFactory, $this->loggerFactory->get('poetry'), $this->state, $this->entityTypeManager, $this->database, $this->requestStack);
   }
 
 }


### PR DESCRIPTION
## OPENEUROPA-2172

### Description

Currently we are injecting a custom logger channel that only uses the dblog logger. The goal of the PR is to create a new custom LoggerChannelFactory that will return our custom logger channel if prompted, allowing it to use all the loggers available in the site.

### Change log

- Added: PoetryLoggerChannelFactory class.
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

