### PR TITLE
OPENEUROPA-2190: Add tests for translator configuration.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "phpunit/phpunit": "~6.0",
         "symfony/browser-kit": "~4.0",
         "ec-europa/oe-poetry-client": "dev-master",
-        "zendframework/zend-diactoros": "~1.8"
+        "zendframework/zend-diactoros": "~1.8",
+        "behat/mink-selenium2-driver": "1.4.x-dev as 1.3.x-dev"
     },
     "_readme": [
         "We explicitly require consolidation/robo to allow lower 'composer update --prefer-lowest' to complete successfully.",

--- a/modules/oe_translation_poetry/src/Form/PoetryCheckoutFormBase.php
+++ b/modules/oe_translation_poetry/src/Form/PoetryCheckoutFormBase.php
@@ -237,6 +237,16 @@ abstract class PoetryCheckoutFormBase extends FormBase {
       ->setDestination('PUBLIC')
       ->setType('INTER');
 
+    // Add the organisation information.
+    $organisation_information = [
+      'setResponsible' => 'responsible',
+      'setAuthor' => 'author',
+      'setRequester' => 'requester',
+    ];
+    foreach ($organisation_information as $method => $name) {
+      $details->$method($form_state->getValue('details')['organisation'][$name]);
+    }
+
     $message->setDetails($details);
 
     // Build the contact information.
@@ -244,13 +254,6 @@ abstract class PoetryCheckoutFormBase extends FormBase {
       $message->withContact()
         ->setType($name)
         ->setNickname($form_state->getValue('details')['contact'][$name]);
-    }
-
-    // Build the organisation information.
-    foreach (PoetryTranslatorUI::getContactFieldNames('organisation') as $name => $label) {
-      $message->withContact()
-        ->setType($name)
-        ->setNickname($form_state->getValue('details')['organisation'][$name]);
     }
 
     // Build the return endpoint information.

--- a/modules/oe_translation_poetry/tests/Functional/PoetryConfigurationTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryConfigurationTest.php
@@ -14,30 +14,14 @@ use Drupal\oe_translation_poetry_mock\PoetryMock;
 class PoetryConfigurationTest extends PoetryTranslationTestBase {
 
   /**
-   * {@inheritdoc}
-   */
-  protected function setUp() {
-    parent::setUp();
-
-    /** @var \Drupal\user\RoleInterface $role */
-    $role = $this->entityTypeManager->getStorage('user_role')->load('translator');
-    $permissions = $role->getPermissions();
-    $permissions[] = 'administer tmgmt';
-    /** @var \Drupal\user\RoleInterface $role */
-    $user = $this->drupalCreateUser($permissions);
-    $this->drupalLogin($user);
-  }
-
-  /**
    * Tests the configuration of the Poetry translator plugin.
-   *
-   * @throws \Behat\Mink\Exception\ExpectationException
-   * @throws \Behat\Mink\Exception\ResponseTextException
-   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
-   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
-   * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function testTranslatorConfiguration() {
+    // Log in with a TMGMT administrator user to edit the Poetry translator.
+    /** @var \Drupal\user\RoleInterface $role */
+    $user = $this->drupalCreateUser(['administer tmgmt']);
+    $this->drupalLogin($user);
+
     $contact_values = [
       'author' => 'contactAuthor',
       'secretary' => 'contactSecretary',
@@ -72,6 +56,12 @@ class PoetryConfigurationTest extends PoetryTranslationTestBase {
       $form_values,
       'Save');
     $this->assertSession()->pageTextContains($translator->label() . " configuration has been updated.");
+
+    // Log in with a translator user to finalize the translation process.
+    /** @var \Drupal\user\RoleInterface $role */
+    $role = $this->entityTypeManager->getStorage('user_role')->load('translator');
+    $user = $this->drupalCreateUser($role->getPermissions());
+    $this->drupalLogin($user);
 
     // Create a node to translate.
     /** @var \Drupal\node\NodeStorageInterface $node_storage */

--- a/modules/oe_translation_poetry/tests/Functional/PoetryConfigurationTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryConfigurationTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_translation_poetry\Functional;
+
+use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Core\Url;
+use Drupal\oe_translation_poetry_mock\PoetryMock;
+
+/**
+ * Tests the configuration of Poetry translators works as intended.
+ */
+class PoetryConfigurationTest extends PoetryTranslationTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    /** @var \Drupal\user\RoleInterface $role */
+    $role = $this->entityTypeManager->getStorage('user_role')->load('translator');
+    $permissions = $role->getPermissions();
+    $permissions[] = 'administer tmgmt';
+    /** @var \Drupal\user\RoleInterface $role */
+    $user = $this->drupalCreateUser($permissions);
+    $this->drupalLogin($user);
+  }
+
+  /**
+   * Tests the configuration of the Poetry translator plugin.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   * @throws \Behat\Mink\Exception\ResponseTextException
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testTranslatorConfiguration() {
+    $contact_values = [
+      'author' => 'contactAuthor',
+      'secretary' => 'contactSecretary',
+      'contact' => 'contactContact',
+      'responsible' => 'contactResponsible',
+    ];
+
+    $organisation_values = [
+      'responsible' => 'orgResponsible',
+      'author' => 'orgAuthor',
+      'requester' => 'orgRequester',
+    ];
+
+    // Save custom configuration values on the translator.
+    /** @var \Drupal\tmgmt\TranslatorInterface $translator */
+    $translator = $this->container->get('entity_type.manager')->getStorage('tmgmt_translator')->load('poetry');
+    $form_values = [
+      'settings[service_wsdl]' => PoetryMock::getWsdlUrl(),
+      'settings[identifier_code]' => 'testCode',
+      'settings[title_prefix]' => 'testPrefix',
+      'settings[site_id]' => 'testId',
+      'settings[application_reference]' => 'testRef',
+    ];
+    foreach ($contact_values as $field => $value) {
+      $form_values['settings[contact][' . $field . ']'] = $value;
+    }
+    foreach ($organisation_values as $field => $value) {
+      $form_values['settings[organisation][' . $field . ']'] = $value;
+    }
+
+    $this->drupalPostForm(Url::fromRoute('entity.tmgmt_translator.edit_form', ['tmgmt_translator' => $translator->id()]),
+      $form_values,
+      'Save');
+    $this->assertSession()->pageTextContains($translator->label() . " configuration has been updated.");
+
+    // Create a node to translate.
+    /** @var \Drupal\node\NodeStorageInterface $node_storage */
+    $node_storage = $this->entityTypeManager->getStorage('node');
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $node_storage->create([
+      'type' => 'page',
+      'title' => 'My first node',
+    ]);
+    $node->save();
+
+    // Select some languages to translate.
+    $this->createInitialTranslationJobs($node, ['bg' => 'Bulgarian']);
+    $job = $this->jobStorage->load(1);
+
+    // Check that the fields contain the default values.
+    foreach ($contact_values as $field => $value) {
+      $this->assertsession()->fieldValueEquals('details[contact][' . $field . ']', $value);
+    }
+    foreach ($organisation_values as $field => $value) {
+      $this->assertsession()->fieldValueEquals('details[organisation][' . $field . ']', $value);
+    }
+
+    // Submit the request form.
+    $date = new \DateTime();
+    $date->modify('+ 7 days');
+    $values = [
+      'details[date]' => $date->format('Y-m-d'),
+    ];
+    $this->drupalPostForm(NULL, $values, 'Send request');
+    $this->assertSession()->pageTextContains('The request has been sent to DGT.');
+
+    // Check the request sent and assert the saved values where used.
+    $result = $this->container->get('database')
+      ->select('watchdog', 'w')
+      ->range(0, 1)
+      ->fields('w', ['variables'])
+      ->condition('message', 'Poetry event <strong>@name</strong>: <br /><br />Username: <strong>@username</strong> <br /><br />Password: <strong>@password</strong> \n\n<pre>@message</pre>')
+      ->execute()
+      ->fetchCol(0);
+    $this->assertCount(1, $result);
+    $logged_message = trim(unserialize(reset($result))['@message'], "'");
+    $message = simplexml_load_string($logged_message);
+    $request = $message->request;
+
+    // Check identifier with the custom code.
+    $this->assertEqual((string) $request->attributes()['id'], $form_values['settings[identifier_code]'] . '/2019/EWCMS_SEQUENCE/0/0/TRA');
+
+    // Check the title.
+    $title = (string) new FormattableMarkup('@prefix: @site_id - @title', [
+      '@prefix' => $form_values['settings[title_prefix]'],
+      '@site_id' => $form_values['settings[site_id]'],
+      '@title' => $job->label(),
+    ]);
+    $this->assertEquals($title, (string) $request->demande->titre);
+
+    // Check the application reference.
+    $this->assertEquals($form_values['settings[application_reference]'], (string) $request->demande->applicationReference);
+
+    // Check organisation details.
+    $this->assertEquals($organisation_values['author'], (string) $request->demande->organisationAuteur);
+    $this->assertEquals($organisation_values['responsible'], (string) $request->demande->organisationResponsable);
+    $this->assertEquals($organisation_values['requester'], (string) $request->demande->serviceDemandeur);
+
+    // Check the contact information.
+    $contacts = $request->contacts;
+    foreach ($contacts as $contact) {
+      $this->assertEquals($contact_values[(string) $contact->attributes()['type']], (string) $contact->contactNickname);
+    }
+  }
+
+}

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_translation_poetry\Functional;
 
-use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Drupal\tmgmt\JobInterface;
@@ -237,30 +236,6 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
     ];
 
     $this->assertJobsPoetryRequestIdValues($this->jobStorage->loadMultiple(), $expected_poetry_request_id);
-  }
-
-  /**
-   * Chooses the languages to translate from the overview page.
-   *
-   * @param \Drupal\node\NodeInterface $node
-   *   The node.
-   * @param array $languages
-   *   The language codes.
-   */
-  protected function createInitialTranslationJobs(NodeInterface $node, array $languages): void {
-    $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
-    $this->assertSession()->pageTextContains('Translations of ' . $node->label());
-
-    $values = [];
-    foreach (array_keys($languages) as $language) {
-      $values["languages[$language]"] = 1;
-    }
-
-    $target_languages = count($languages) > 1 ? implode(', ', $languages) : array_shift($languages);
-    $expected_title = new FormattableMarkup('Send request to DG Translation for @entity in @target_languages', ['@entity' => $node->label(), '@target_languages' => $target_languages]);
-
-    $this->drupalPostForm($node->toUrl('drupal:content-translation-overview'), $values, 'Request DGT translation for the selected languages');
-    $this->assertSession()->pageTextContains($expected_title->__toString());
   }
 
   /**

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationTestBase.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationTestBase.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_translation_poetry\Functional;
 
+use Drupal\Component\Render\FormattableMarkup;
+use Drupal\node\NodeInterface;
 use Drupal\oe_translation_poetry_mock\PoetryMock;
 use Drupal\Tests\oe_translation\Functional\TranslationTestBase;
 
@@ -85,6 +87,30 @@ class PoetryTranslationTestBase extends TranslationTestBase {
     }
 
     return $grouped;
+  }
+
+  /**
+   * Chooses the languages to translate from the overview page.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node.
+   * @param array $languages
+   *   The language codes.
+   */
+  protected function createInitialTranslationJobs(NodeInterface $node, array $languages): void {
+    $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
+    $this->assertSession()->pageTextContains('Translations of ' . $node->label());
+
+    $values = [];
+    foreach (array_keys($languages) as $language) {
+      $values["languages[$language]"] = 1;
+    }
+
+    $target_languages = count($languages) > 1 ? implode(', ', $languages) : array_shift($languages);
+    $expected_title = new FormattableMarkup('Send request to DG Translation for @entity in @target_languages', ['@entity' => $node->label(), '@target_languages' => $target_languages]);
+
+    $this->drupalPostForm($node->toUrl('drupal:content-translation-overview'), $values, 'Request DGT translation for the selected languages');
+    $this->assertSession()->pageTextContains($expected_title->__toString());
   }
 
 }


### PR DESCRIPTION
## OPENEUROPA-2190

### Description

Browser test that checks that we can configure our translator and that all its relevant values are picked up where needed

### Change log

- Added: Translator configuration test.
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

