### PR TITLE
OPENEUROPA-2535

### DIFF
--- a/modules/oe_translation_poetry/modules/oe_translation_poetry_html_formatter/templates/poetry-html-template.html.twig
+++ b/modules/oe_translation_poetry/modules/oe_translation_poetry_html_formatter/templates/poetry-html-template.html.twig
@@ -16,7 +16,7 @@
           label="{{ field['#parent_label']|first }}"
           context="{{ field['#key'] }}"
           -->
-          <div class="atom" id="{{ field_key }}">{{ field['#text'] }}</div>
+          <div class="atom" id="{{ field_key }}">{{ field['#text']|raw }}</div>
         {% endfor %}
       </div>
     {% endfor %}

--- a/modules/oe_translation_poetry/modules/oe_translation_poetry_html_formatter/tests/fixtures/formatted-content.html
+++ b/modules/oe_translation_poetry/modules/oe_translation_poetry_html_formatter/tests/fixtures/formatted-content.html
@@ -6,7 +6,6 @@
     <meta name="JobID" content="1" />
     <meta name="languageSource" content="en-us" />
     <meta name="languageTarget" content="de-ch" />
-
     <title>Job ID 1</title>
   </head>
   <body>
@@ -16,6 +15,11 @@
           context="[1][title][0][value]"
           -->
           <div class="atom" id="bMV1bdGl0bGVdWzBdW3ZhbHVl">English title</div>
+                  <!--
+          label="translatable_text_field"
+          context="[1][translatable_text_field][0][value]"
+          -->
+          <div class="atom" id="bMV1bdHJhbnNsYXRhYmxlX3RleHRfZmllbGRdWzBdW3ZhbHVl"><h1>This is a heading</h1><p>This is a paragraph</p></div>
               </div>
       </body>
 </html>


### PR DESCRIPTION
## OPENEUROPA-2535

### Description

By default when you print data in twig, it encodes the html.

By adding |raw it ensures that html tags are preserved as DGT expects it.

