### PR TITLE
OPENEUROPA-2555: Restrict the applicability of translator plugins. 

### DIFF
--- a/modules/oe_translation_poetry/modules/oe_translation_poetry_mock/src/EventSubscriber/ContentTranslationOverviewAlterSubscriber.php
+++ b/modules/oe_translation_poetry/modules/oe_translation_poetry_mock/src/EventSubscriber/ContentTranslationOverviewAlterSubscriber.php
@@ -158,6 +158,7 @@ class ContentTranslationOverviewAlterSubscriber implements EventSubscriberInterf
     $query->join('tmgmt_job_item', 'job_item', 'job.tjid = job_item.tjid');
     $query->fields('job', ['tjid', 'target_language']);
     $query->condition('job_item.item_id', $entity->id());
+    $query->condition('job_item.item_type', $entity->getEntityTypeId());
     $query->condition('job.state', $state, '=');
     if ($poetry_state) {
       $query->condition('job.poetry_state', $poetry_state, '=');

--- a/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
+++ b/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
@@ -572,6 +572,7 @@ class PoetryTranslator extends TranslatorPluginBase implements AlterableTranslat
     $query->fields('job', ['tjid', 'target_language']);
     $query->fields('job_item', ['tjiid']);
     $query->condition('job_item.item_id', $entity->id());
+    $query->condition('job_item.item_type', $entity->getEntityTypeId());
     $query->condition('job.translator', 'poetry', '=');
     return $query;
   }

--- a/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
+++ b/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
@@ -590,7 +590,7 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
   /**
    * {@inheritdoc}
    */
-  public function access(JobInterface $job, string $operation, AccountInterface $account): ?AccessResultInterface {
+  public function accessJob(JobInterface $job, string $operation, AccountInterface $account): ?AccessResultInterface {
     if ($operation !== 'delete') {
       return NULL;
     }

--- a/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
+++ b/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
@@ -11,6 +11,7 @@ use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\Query\SelectInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -22,6 +23,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\oe_translation\AlterableTranslatorInterface;
+use Drupal\oe_translation\ApplicableTranslatorInterface;
 use Drupal\oe_translation\Event\TranslationAccessEvent;
 use Drupal\oe_translation\JobAccessTranslatorInterface;
 use Drupal\oe_translation\RouteProvidingTranslatorInterface;
@@ -51,7 +53,7 @@ use Symfony\Component\Routing\RouteCollection;
  *
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
-class PoetryTranslator extends TranslatorPluginBase implements AlterableTranslatorInterface, ContainerFactoryPluginInterface, RouteProvidingTranslatorInterface, JobAccessTranslatorInterface {
+class PoetryTranslator extends TranslatorPluginBase implements ApplicableTranslatorInterface, AlterableTranslatorInterface, ContainerFactoryPluginInterface, RouteProvidingTranslatorInterface, JobAccessTranslatorInterface {
 
   /**
    * Status indicating that the translation is ongoing in Poetry.
@@ -209,6 +211,14 @@ class PoetryTranslator extends TranslatorPluginBase implements AlterableTranslat
       $container->get('database'),
       $container->get('event_dispatcher')
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(EntityTypeInterface $entityType): bool {
+    // We can only translate Node entities with Poetry.
+    return $entityType->id() === 'node';
   }
 
   /**

--- a/modules/oe_translation_poetry/src/Poetry.php
+++ b/modules/oe_translation_poetry/src/Poetry.php
@@ -288,6 +288,7 @@ class Poetry implements PoetryInterface {
     $query->join('tmgmt_job_item', 'job_item', 'job.tjid = job_item.tjid');
     $query->fields('job');
     $query->condition('job_item.item_id', $entity->id());
+    $query->condition('job_item.item_type', $entity->getEntityTypeId());
     $query->condition('job.translator', 'poetry');
     // Do not include unprocessed Jobs. These are the ones which have not been
     // ever sent to Poetry.

--- a/oe_translation.module
+++ b/oe_translation.module
@@ -23,6 +23,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\oe_translation\ContentEntitySource;
 use Drupal\oe_translation\LocalTranslatorInterface;
+use Drupal\oe_translation\OeTranslationHandler;
 use Drupal\oe_translation\TranslationModerationHandler;
 use Drupal\tmgmt_content\DefaultFieldProcessor;
 
@@ -64,9 +65,13 @@ function oe_translation_form_tmgmt_job_item_edit_form_alter(&$form, FormStateInt
   /** @var \Drupal\tmgmt\JobItemInterface $job_item */
   $job_item = $form_state->getBuildInfo()['callback_object']->getEntity();
   $job = $job_item->getJob();
+  /** @var \Drupal\oe_translation\OeTranslationHandler $handler */
+  $handler = \Drupal::entityTypeManager()->getHandler($job_item->getItemType(), 'oe_translation');
+  $supported_translators = $handler->getSupportedTranslators();
   try {
-    $translator_plugin = \Drupal::service('plugin.manager.tmgmt.translator')->createInstance($job->getTranslator()->getPluginId());
-    if ($translator_plugin instanceof AlterableTranslatorInterface) {
+    $plugin_id = $job->getTranslator()->getPluginId();
+    $translator_plugin = \Drupal::service('plugin.manager.tmgmt.translator')->createInstance($plugin_id);
+    if ($translator_plugin instanceof AlterableTranslatorInterface && in_array($plugin_id, $supported_translators)) {
       $translator_plugin->jobItemFormAlter($form, $form_state);
     }
   }
@@ -85,10 +90,13 @@ function oe_translation_entity_type_alter(array &$entity_types) {
       $entity_type->setClass(JobItem::class);
     }
 
-    // Change the access handler with our own.
+    // Change the access handler with our own for the Job entity.
     if ($entity_type_id === 'tmgmt_job') {
       $entity_type->setHandlerClass('access', JobAccessHandler::class);
     }
+
+    // Add the OpenEuropa translation handler to all entity types.
+    $entity_type->setHandlerClass('oe_translation', OeTranslationHandler::class);
 
     // Change the moderation handler if set to our own override.
     if (!$entity_type->hasHandlerClass('moderation')) {

--- a/oe_translation.services.yml
+++ b/oe_translation.services.yml
@@ -1,7 +1,7 @@
 services:
   oe_translation.route_subscriber:
     class: Drupal\oe_translation\Routing\RouteSubscriber
-    arguments: ['@content_translation.manager']
+    arguments: ['@content_translation.manager', '@entity_type.manager']
     tags:
       - { name: event_subscriber }
   oe_translation.translation_provider_routes:
@@ -17,6 +17,7 @@ services:
       - { name: event_subscriber }
   oe_translation.route_access_checker:
     class: Drupal\oe_translation\Access\TranslationRouteAccess
+    arguments: ['@entity_type.manager']
     tags:
       - { name: access_check, applies_to: _access_oe_translation }
   oe_translation.request_subscriber:

--- a/src/Access/JobAccessHandler.php
+++ b/src/Access/JobAccessHandler.php
@@ -25,7 +25,7 @@ class JobAccessHandler extends JobAccessControlHandler {
     /** @var \Drupal\tmgmt\JobInterface $entity */
     $plugin = $entity->getTranslatorPlugin();
     if ($plugin instanceof JobAccessTranslatorInterface) {
-      $access = $plugin->access($entity, $operation, $account);
+      $access = $plugin->accessJob($entity, $operation, $account);
       if ($access instanceof AccessResultInterface) {
         return $access;
       }

--- a/src/Access/TranslationRouteAccess.php
+++ b/src/Access/TranslationRouteAccess.php
@@ -6,6 +6,7 @@ namespace Drupal\oe_translation\Access;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\Access\AccessInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -15,6 +16,23 @@ use Symfony\Component\Routing\Route;
  * Route access handler for the content translation routes.
  */
 class TranslationRouteAccess implements AccessInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * TranslationRouteAccess constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
 
   /**
    * Access callback to prevent the regular Drupal translations.
@@ -39,10 +57,11 @@ class TranslationRouteAccess implements AccessInterface {
    */
   public function access(Route $route, RouteMatchInterface $route_match, AccountInterface $account, string $source = NULL, string $target = NULL, string $language = NULL, string $entity_type_id = NULL): AccessResultInterface {
     $operation = $route->getRequirement('_access_oe_translation');
-    // Nobody should ever create or edit translations using the regular core
-    // flow.
+
+    // Drupal core translation should not be used if this access checker is
+    // in place.
     if (in_array($operation, ['create', 'update'])) {
-      return AccessResult::forbidden();
+      return AccessResult::forbidden()->setReason('Core translation is not accessible for this entity type.');
     }
 
     // We allow the deletion to happen still in case.

--- a/src/ApplicableTranslatorInterface.php
+++ b/src/ApplicableTranslatorInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_translation;
+
+use Drupal\Core\Entity\EntityTypeInterface;
+
+/**
+ * TMGMT translators that specify which entity types they work with.
+ */
+interface ApplicableTranslatorInterface {
+
+  /**
+   * Checks whether the translator can be used with this entity type.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entityType
+   *   The entity type.
+   *
+   * @return bool
+   *   Whether it applies.
+   */
+  public function applies(EntityTypeInterface $entityType): bool;
+
+}

--- a/src/JobAccessTranslatorInterface.php
+++ b/src/JobAccessTranslatorInterface.php
@@ -28,6 +28,6 @@ interface JobAccessTranslatorInterface {
    * @return \Drupal\Core\Access\AccessResultInterface
    *   The access or NULL if we want to defer to the default access checking.
    */
-  public function access(JobInterface $job, string $operation, AccountInterface $account): ?AccessResultInterface;
+  public function accessJob(JobInterface $job, string $operation, AccountInterface $account): ?AccessResultInterface;
 
 }

--- a/src/OeTranslationHandler.php
+++ b/src/OeTranslationHandler.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_translation;
+
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\Core\Entity\EntityHandlerInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\tmgmt\TranslatorManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Entity handler for the OpenEuropa translation system.
+ */
+class OeTranslationHandler implements EntityHandlerInterface {
+
+  /**
+   * The translator manager.
+   *
+   * @var \Drupal\tmgmt\TranslatorManager
+   */
+  protected $translatorManager;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity type.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeInterface
+   */
+  protected $entityType;
+
+  /**
+   * OeTranslationHandler constructor.
+   *
+   * @param \Drupal\tmgmt\TranslatorManager $translatorManager
+   *   The translator manager.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   The entity type.
+   */
+  public function __construct(TranslatorManager $translatorManager, EntityTypeManagerInterface $entityTypeManager, EntityTypeInterface $entity_type) {
+    $this->translatorManager = $translatorManager;
+    $this->entityTypeManager = $entityTypeManager;
+    $this->entityType = $entity_type;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    return new static(
+      $container->get('plugin.manager.tmgmt.translator'),
+      $container->get('entity_type.manager'),
+      $entity_type
+    );
+  }
+
+  /**
+   * Returns the supported translators for this entity type.
+   *
+   * @return array
+   *   The supported translators.
+   */
+  public function getSupportedTranslators(): array {
+    $supported = [];
+    /** @var \Drupal\tmgmt\TranslatorInterface[] $translators */
+    $translators = $this->entityTypeManager->getStorage('tmgmt_translator')->loadMultiple();
+    foreach ($translators as $translator) {
+      $plugin_id = $translator->getPluginId();
+      try {
+        $translator_plugin = $this->translatorManager->createInstance($plugin_id);
+        if (!$translator_plugin instanceof ApplicableTranslatorInterface) {
+          continue;
+        }
+
+        if ($translator_plugin->applies($this->entity_type)) {
+          $supported[] = $plugin_id;
+        }
+      }
+      catch (PluginNotFoundException $exception) {
+        continue;
+      }
+    }
+
+    return $supported;
+  }
+
+}

--- a/src/OeTranslationHandler.php
+++ b/src/OeTranslationHandler.php
@@ -82,7 +82,7 @@ class OeTranslationHandler implements EntityHandlerInterface {
           continue;
         }
 
-        if ($translator_plugin->applies($this->entity_type)) {
+        if ($translator_plugin->applies($this->entityType)) {
           $supported[] = $plugin_id;
         }
       }

--- a/src/Plugin/tmgmt/Translator/PermissionTranslator.php
+++ b/src/Plugin/tmgmt/Translator/PermissionTranslator.php
@@ -8,6 +8,8 @@ use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Entity\ContentEntityTypeInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\oe_translation\JobAccessTranslatorInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\oe_translation\ApplicableTranslatorInterface;
 use Drupal\tmgmt_content\Plugin\tmgmt\Source\ContentEntitySource;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Access\AccessManagerInterface;
@@ -55,7 +57,7 @@ use Symfony\Component\Routing\RouteCollection;
  *
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
-class PermissionTranslator extends TranslatorPluginBase implements ContinuousTranslatorInterface, AlterableTranslatorInterface, RouteProvidingTranslatorInterface, LocalTranslatorInterface, ContainerFactoryPluginInterface, JobAccessTranslatorInterface {
+class PermissionTranslator extends TranslatorPluginBase implements ApplicableTranslatorInterface, ContinuousTranslatorInterface, AlterableTranslatorInterface, RouteProvidingTranslatorInterface, LocalTranslatorInterface, ContainerFactoryPluginInterface, JobAccessTranslatorInterface {
 
   /**
    * The current user.
@@ -148,6 +150,14 @@ class PermissionTranslator extends TranslatorPluginBase implements ContinuousTra
       $container->get('request_stack'),
       $container->get('entity_field.manager')
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(EntityTypeInterface $entityType): bool {
+    // We can only translate Node entities with this translator..
+    return $entityType->id() === 'node';
   }
 
   /**

--- a/src/Plugin/tmgmt/Translator/PermissionTranslator.php
+++ b/src/Plugin/tmgmt/Translator/PermissionTranslator.php
@@ -569,7 +569,7 @@ class PermissionTranslator extends TranslatorPluginBase implements ApplicableTra
   /**
    * {@inheritdoc}
    */
-  public function access(JobInterface $job, string $operation, AccountInterface $account): ?AccessResultInterface {
+  public function accessJob(JobInterface $job, string $operation, AccountInterface $account): ?AccessResultInterface {
     if ($operation !== 'delete') {
       return NULL;
     }

--- a/tests/Behat/PoetryTranslationContext.php
+++ b/tests/Behat/PoetryTranslationContext.php
@@ -241,6 +241,7 @@ class PoetryTranslationContext extends RawDrupalContext {
     $query->join('tmgmt_job_item', 'job_item', 'job.tjid = job_item.tjid');
     $query->fields('job', ['tjid', 'target_language']);
     $query->condition('job_item.item_id', $entity->id());
+    $query->condition('job_item.item_type', $entity->getEntityTypeId());
     $query->condition('job.translator', 'poetry', '=');
     return $query;
   }

--- a/tests/Functional/TranslationTestBase.php
+++ b/tests/Functional/TranslationTestBase.php
@@ -56,7 +56,9 @@ class TranslationTestBase extends BrowserTestBase {
 
     /** @var \Drupal\user\RoleInterface $role */
     $role = $this->entityTypeManager->getStorage('user_role')->load('translator');
-    $user = $this->drupalCreateUser($role->getPermissions());
+    $permissions = $role->getPermissions();
+    $permissions[] = 'administer menu';
+    $user = $this->drupalCreateUser($permissions);
 
     $this->drupalLogin($user);
   }

--- a/tests/modules/oe_translation_test/src/Plugin/tmgmt/Translator/TestTranslatorWithInterfaces.php
+++ b/tests/modules/oe_translation_test/src/Plugin/tmgmt/Translator/TestTranslatorWithInterfaces.php
@@ -6,7 +6,9 @@ namespace Drupal\oe_translation_test\Plugin\tmgmt\Translator;
 
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\oe_translation\ApplicableTranslatorInterface;
 use Drupal\tmgmt_local\LocalTaskItemInterface;
 use Drupal\tmgmt\JobInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -29,13 +31,20 @@ use Symfony\Component\Routing\RouteCollection;
  *   map_remote_languages = FALSE
  * )
  */
-class TestTranslatorWithInterfaces extends TranslatorPluginBase implements AlterableTranslatorInterface, RouteProvidingTranslatorInterface, LocalTranslatorInterface {
+class TestTranslatorWithInterfaces extends TranslatorPluginBase implements ApplicableTranslatorInterface, AlterableTranslatorInterface, RouteProvidingTranslatorInterface, LocalTranslatorInterface {
 
   /**
    * {@inheritdoc}
    */
   public function jobItemFormAlter(array &$form, FormStateInterface $form_state): void {
     // Do nothing for now.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(EntityTypeInterface $entityType): bool {
+    return $entityType->id() === 'node';
   }
 
   /**


### PR DESCRIPTION
In this PR we allow again Drupal core translation for certain entity types by creating a way for the existing translator plugins to say which entity types they support. For the ones supported, Drupal core translation is disabled.

This is done using a default `applies()` method on the translator plugins, called by a centralized handler. If a site using this module makes any of the translators work with other entity types, they can extend the handler and include also that one.