### PR TITLE
OPENEUROPA-2535: Using markup in the HTML export.

### DIFF
--- a/modules/oe_translation_poetry/modules/oe_translation_poetry_html_formatter/src/PoetryHtmlFormatter.php
+++ b/modules/oe_translation_poetry/modules/oe_translation_poetry_html_formatter/src/PoetryHtmlFormatter.php
@@ -195,22 +195,8 @@ class PoetryHtmlFormatter implements PoetryContentFormatterInterface {
    *   The renderable array.
    */
   protected function prepareValueRenderable(array $value): array {
-    if (isset($value['#format']) && $value['#format'] !== 'plain_text') {
-      // If we have a text format, we should use it and process the text. If,
-      // however, the format is the core "plain_text" one, we do not want to
-      // use it because it comes with some filters by default such as autp
-      // that we cannot use when sending markup to Poetry. So in that case we
-      // just render with a true plain text.
-      return [
-        '#type' => 'processed_text',
-        '#text' => $value['#text'],
-        '#format' => $value['#format'],
-      ];
-    }
-
-    // Otherwise we default to plain text.
     return [
-      '#plain_text' => $value['#text'],
+      '#markup' => $value['#text'],
     ];
   }
 


### PR DESCRIPTION
The problem with rendering the field values is that format filters kick in and change the markup. So when translations come back from Poetry, they are no longer correct for how the data should be stored. 