### PR TITLE
OPENEUROPA-2252: Allow to request translation updates

### DIFF
--- a/modules/oe_translation_poetry/oe_translation_poetry.module
+++ b/modules/oe_translation_poetry/oe_translation_poetry.module
@@ -90,6 +90,31 @@ function oe_translation_poetry_form_tmgmt_content_translate_form_alter(&$form, F
       ];
     }
   }
+
+  // Enforce the value of the disabled checkboxes so that they get submitted.
+  // This is for the languages that should be included in the translation
+  // update requests automatically.
+  // @see PoetryTranslator::contentTranslationOverviewAlter().
+  $build = $form_state->getBuildInfo()['args'][0];
+  if (!isset($build['#accepted_languages'])) {
+    return;
+  }
+
+  // We force the submission in Poetry update request all the languages for
+  // which the jobs have been accepted, translated or completed in the same
+  // request.
+  $accepted_languages = $build['#accepted_languages'];
+  $translated_languages = $build['#translated_languages'];
+  $completed_languages = $build['#completed_languages'];
+
+  $languages = array_merge($accepted_languages, $translated_languages, $completed_languages);
+  foreach (array_keys($languages) as $langcode) {
+    $form['languages'][$langcode] = [
+      '#type' => 'checkbox',
+      '#disabled' => TRUE,
+      '#value' => 1,
+    ];
+  }
 }
 
 /**

--- a/modules/oe_translation_poetry/src/Event/PoetryRequestTypeEvent.php
+++ b/modules/oe_translation_poetry/src/Event/PoetryRequestTypeEvent.php
@@ -44,7 +44,9 @@ class PoetryRequestTypeEvent extends Event {
    * @param \Drupal\oe_translation_poetry\PoetryRequestType $requestType
    *   The request type constant.
    * @param object|null $jobInfo
-   *   The job information of the current request.
+   *   The job information of the current request. This contains:
+   *     - tjid - the Job ID
+   *     - tjiid -the Job Item ID.
    */
   public function __construct(ContentEntityInterface $entity, PoetryRequestType $requestType, $jobInfo = NULL) {
     $this->entity = $entity;

--- a/modules/oe_translation_poetry/src/Event/PoetryRequestTypeEvent.php
+++ b/modules/oe_translation_poetry/src/Event/PoetryRequestTypeEvent.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_translation_poetry\Event;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event class for determining what kind of Poetry request can be made.
+ */
+class PoetryRequestTypeEvent extends Event {
+
+  const EVENT = 'oe_translation_poetry.request_type_event';
+
+  /**
+   * The entity being translated.
+   *
+   * @var \Drupal\Core\Entity\ContentEntityInterface
+   */
+  protected $entity;
+
+  /**
+   * The request type constant.
+   *
+   * @var string
+   */
+  protected $requestType;
+
+  /**
+   * The job information of the current request.
+   *
+   * @var array
+   */
+  protected $jobInfo;
+
+  /**
+   * PoetryRequestTypeEvent constructor.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity being translated.
+   * @param string $requestType
+   *   The request type constant.
+   * @param object|null $jobInfo
+   *   The job information of the current request.
+   */
+  public function __construct(ContentEntityInterface $entity, string $requestType, $jobInfo = NULL) {
+    $this->entity = $entity;
+    $this->requestType = $requestType;
+    $this->jobInfo = $jobInfo;
+  }
+
+  /**
+   * Returns the entity being translated.
+   *
+   * @return \Drupal\Core\Entity\ContentEntityInterface
+   *   The entity.
+   */
+  public function getEntity(): ContentEntityInterface {
+    return $this->entity;
+  }
+
+  /**
+   * Returns the request type constant.
+   *
+   * @return string
+   *   The request type.
+   */
+  public function getRequestType(): string {
+    return $this->requestType;
+  }
+
+  /**
+   * Sets the request type constant.
+   *
+   * @param string $requestType
+   *   The request type.
+   */
+  public function setRequestType(string $requestType): void {
+    $this->requestType = $requestType;
+  }
+
+  /**
+   * Returns the job info.
+   *
+   * @return object|null
+   *   The job info.
+   */
+  public function getJobInfo(): ?\stdClass {
+    return $this->jobInfo;
+  }
+
+}

--- a/modules/oe_translation_poetry/src/Event/PoetryRequestTypeEvent.php
+++ b/modules/oe_translation_poetry/src/Event/PoetryRequestTypeEvent.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\oe_translation_poetry\Event;
 
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\oe_translation_poetry\PoetryRequestType;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -24,7 +25,7 @@ class PoetryRequestTypeEvent extends Event {
   /**
    * The request type constant.
    *
-   * @var string
+   * @var \Drupal\oe_translation_poetry\PoetryRequestType
    */
   protected $requestType;
 
@@ -40,12 +41,12 @@ class PoetryRequestTypeEvent extends Event {
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    *   The entity being translated.
-   * @param string $requestType
+   * @param \Drupal\oe_translation_poetry\PoetryRequestType $requestType
    *   The request type constant.
    * @param object|null $jobInfo
    *   The job information of the current request.
    */
-  public function __construct(ContentEntityInterface $entity, string $requestType, $jobInfo = NULL) {
+  public function __construct(ContentEntityInterface $entity, PoetryRequestType $requestType, $jobInfo = NULL) {
     $this->entity = $entity;
     $this->requestType = $requestType;
     $this->jobInfo = $jobInfo;
@@ -62,22 +63,22 @@ class PoetryRequestTypeEvent extends Event {
   }
 
   /**
-   * Returns the request type constant.
+   * Returns the request type.
    *
-   * @return string
+   * @return \Drupal\oe_translation_poetry\PoetryRequestType
    *   The request type.
    */
-  public function getRequestType(): string {
+  public function getRequestType(): PoetryRequestType {
     return $this->requestType;
   }
 
   /**
-   * Sets the request type constant.
+   * Sets the request type.
    *
-   * @param string $requestType
+   * @param \Drupal\oe_translation_poetry\PoetryRequestType $requestType
    *   The request type.
    */
-  public function setRequestType(string $requestType): void {
+  public function setRequestType(PoetryRequestType $requestType): void {
     $this->requestType = $requestType;
   }
 

--- a/modules/oe_translation_poetry/src/Form/NewTranslationRequestForm.php
+++ b/modules/oe_translation_poetry/src/Form/NewTranslationRequestForm.php
@@ -51,6 +51,7 @@ class NewTranslationRequestForm extends PoetryCheckoutFormBase {
       '#type' => 'fieldset',
       '#title' => $this->t('Contact information'),
     ];
+
     foreach (PoetryTranslatorUI::getContactFieldNames('contact') as $name => $label) {
       $form['details']['contact'][$name] = [
         '#type' => 'textfield',
@@ -64,6 +65,7 @@ class NewTranslationRequestForm extends PoetryCheckoutFormBase {
       '#type' => 'fieldset',
       '#title' => $this->t('Organisation information'),
     ];
+
     foreach (PoetryTranslatorUI::getContactFieldNames('organisation') as $name => $label) {
       $form['details']['organisation'][$name] = [
         '#type' => 'textfield',
@@ -77,6 +79,7 @@ class NewTranslationRequestForm extends PoetryCheckoutFormBase {
       '#title' => $this->t('Comment'),
       '#description' => $this->t('Optional remark about the translation request.'),
     ];
+
     return $form;
   }
 
@@ -154,7 +157,7 @@ class NewTranslationRequestForm extends PoetryCheckoutFormBase {
     $return->setPath('handle');
     // The return is a webservice and not an email.
     $return->setType('webService');
-    $return->setAction($this->getRequestOperation());
+    $return->setAction('INSERT');
     $message->setReturnAddress($return);
 
     $source = $message->withSource();
@@ -172,7 +175,7 @@ class NewTranslationRequestForm extends PoetryCheckoutFormBase {
       $message->withTarget()
         ->setLanguage(strtoupper($job->getRemoteTargetLanguage()))
         ->setFormat('HTML')
-        ->setAction($this->getRequestOperation())
+        ->setAction('INSERT')
         ->setDelay($formatted_date);
     }
 
@@ -198,13 +201,6 @@ class NewTranslationRequestForm extends PoetryCheckoutFormBase {
       $this->redirectBack($form_state);
       $queue->reset();
     }
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function getRequestOperation(): string {
-    return 'INSERT';
   }
 
 }

--- a/modules/oe_translation_poetry/src/Form/NewTranslationRequestForm.php
+++ b/modules/oe_translation_poetry/src/Form/NewTranslationRequestForm.php
@@ -4,6 +4,12 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_translation_poetry\Form;
 
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
+use Drupal\oe_translation_poetry\PoetryTranslatorUI;
+
 /**
  * Form for requesting new translations.
  */
@@ -14,6 +20,184 @@ class NewTranslationRequestForm extends PoetryCheckoutFormBase {
    */
   public function getFormId() {
     return 'oe_translation_poetry_new_translation_request';
+  }
+
+  /**
+   * Returns the title of the form page.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $node
+   *   The node entity to use when generating the title.
+   *
+   * @return \Drupal\Core\StringTranslation\TranslatableMarkup
+   *   The title for the form page.
+   */
+  public function getPageTitle(ContentEntityInterface $node = NULL): TranslatableMarkup {
+    $queue = $this->queueFactory->get($node);
+    $entity = $queue->getEntity();
+    $target_languages = $queue->getTargetLanguages();
+    $target_languages = count($target_languages) > 1 ? implode(', ', $target_languages) : array_shift($target_languages);
+    return $this->t('Send request to DG Translation for <em>@entity</em> in <em>@target_languages</em>', ['@entity' => $entity->label(), '@target_languages' => $target_languages]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $translator_settings = $this->poetry->getTranslatorSettings();
+    $form = parent::buildForm($form, $form_state);
+
+    $default_contact = $translator_settings['contact'] ?? [];
+    $form['details']['contact'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Contact information'),
+    ];
+    foreach (PoetryTranslatorUI::getContactFieldNames('contact') as $name => $label) {
+      $form['details']['contact'][$name] = [
+        '#type' => 'textfield',
+        '#title' => $label,
+        '#default_value' => $default_contact[$name] ?? '',
+        '#required' => TRUE,
+      ];
+    }
+    $default_organisation = $translator_settings['organisation'] ?? [];
+    $form['details']['organisation'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Organisation information'),
+    ];
+    foreach (PoetryTranslatorUI::getContactFieldNames('organisation') as $name => $label) {
+      $form['details']['organisation'][$name] = [
+        '#type' => 'textfield',
+        '#title' => $label,
+        '#default_value' => $default_organisation[$name] ?? '',
+        '#required' => TRUE,
+      ];
+    }
+    $form['details']['comment'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Comment'),
+      '#description' => $this->t('Optional remark about the translation request.'),
+    ];
+    return $form;
+  }
+
+  /**
+   * Submits the request to Poetry.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function submitRequest(array &$form, FormStateInterface $form_state): void {
+    $entity = $form_state->get('entity');
+    $queue = $this->queueFactory->get($entity);
+    $translator_settings = $this->poetry->getTranslatorSettings();
+    $jobs = $queue->getAllJobs();
+    $identifier = $this->poetry->getIdentifierForContent($entity);
+    $identifier->setProduct($this->requestType);
+
+    $date = new \DateTime($form_state->getValue('details')['date']);
+    $formatted_date = $date->format('d/m/Y');
+
+    /** @var \EC\Poetry\Messages\Requests\CreateTranslationRequest $message */
+    $message = $this->poetry->get('request.create_translation_request');
+    $message->setIdentifier($identifier);
+
+    // Build the details.
+    $details = $message->withDetails();
+    $details->setDelay($formatted_date);
+
+    if ($form_state->getValue('details')['comment']) {
+      $details->setRemark($form_state->getValue('details')['comment']);
+    }
+
+    // We use the formatted identifier as the user reference.
+    $details->setClientId($identifier->getFormattedIdentifier());
+    $title = $this->createRequestTitle(reset($jobs));
+    $details->setTitle($title);
+    $details->setApplicationId($translator_settings['application_reference']);
+    $details->setReferenceFilesRemark($entity->toUrl()->setAbsolute()->toString());
+    $details
+      ->setProcedure('NEANT')
+      ->setDestination('PUBLIC')
+      ->setType('INTER');
+
+    // Add the organisation information.
+    $organisation_information = [
+      'setResponsible' => 'responsible',
+      'setAuthor' => 'author',
+      'setRequester' => 'requester',
+    ];
+    foreach ($organisation_information as $method => $name) {
+      $details->$method($form_state->getValue('details')['organisation'][$name]);
+    }
+
+    $message->setDetails($details);
+
+    // Build the contact information.
+    foreach (PoetryTranslatorUI::getContactFieldNames('contact') as $name => $label) {
+      $message->withContact()
+        ->setType($name)
+        ->setNickname($form_state->getValue('details')['contact'][$name]);
+    }
+
+    // Build the return endpoint information.
+    $settings = $this->poetry->getSettings();
+    $username = $settings['notification.username'] ?? NULL;
+    $password = $settings['notification.password'] ?? NULL;
+    $return = $message->withReturnAddress();
+    $return->setUser($username);
+    $return->setPassword($password);
+    // The notification endpoint WSDL.
+    $return->setAddress(Url::fromRoute('oe_translation_poetry.notifications')->setAbsolute()->toString() . '?wsdl');
+    // The notification endpoint WSDL action method.
+    $return->setPath('handle');
+    // The return is a webservice and not an email.
+    $return->setType('webService');
+    $return->setAction($this->getRequestOperation());
+    $message->setReturnAddress($return);
+
+    $source = $message->withSource();
+    $source->setFormat('HTML');
+    $source->setName('content.html');
+    $formatted_content = $this->contentFormatter->export(reset($jobs));
+    $source->setFile(base64_encode($formatted_content->__toString()));
+    $source->setLegiswriteFormat('No');
+    $source->withSourceLanguage()
+      ->setCode(strtoupper($entity->language()->getId()))
+      ->setPages(1);
+    $message->setSource($source);
+
+    foreach ($jobs as $job) {
+      $message->withTarget()
+        ->setLanguage(strtoupper($job->getRemoteTargetLanguage()))
+        ->setFormat('HTML')
+        ->setAction($this->getRequestOperation())
+        ->setDelay($formatted_date);
+    }
+
+    try {
+      $client = $this->poetry->getClient();
+      /** @var \EC\Poetry\Messages\Responses\ResponseInterface $response */
+      $response = $client->send($message);
+      $this->handlePoetryResponse($response, $form_state);
+
+      // If we request a new number by setting a sequence, update the global
+      // identifier number with the new number that came for future requests.
+      if ($identifier->getSequence()) {
+        $this->poetry->setGlobalIdentifierNumber($response->getIdentifier()->getNumber());
+      }
+
+      $this->redirectBack($form_state);
+      $queue->reset();
+      $this->messenger->addStatus($this->t('The request has been sent to DGT.'));
+    }
+    catch (\Exception $exception) {
+      $this->logger->error($exception->getMessage());
+      $this->messenger->addError($this->t('There was an error making the request to DGT.'));
+      $this->redirectBack($form_state);
+      $queue->reset();
+    }
   }
 
   /**

--- a/modules/oe_translation_poetry/src/Form/PoetryCheckoutFormBase.php
+++ b/modules/oe_translation_poetry/src/Form/PoetryCheckoutFormBase.php
@@ -93,14 +93,6 @@ abstract class PoetryCheckoutFormBase extends FormBase {
   }
 
   /**
-   * The operation of the request: CREATE, UPDATE, DELETE.
-   *
-   * @return string
-   *   The operation.
-   */
-  abstract protected function getRequestOperation(): string;
-
-  /**
    * Form constructor.
    *
    * @param array $form

--- a/modules/oe_translation_poetry/src/Form/PoetryCheckoutFormBase.php
+++ b/modules/oe_translation_poetry/src/Form/PoetryCheckoutFormBase.php
@@ -6,6 +6,7 @@ namespace Drupal\oe_translation_poetry\Form;
 
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
@@ -58,6 +59,13 @@ abstract class PoetryCheckoutFormBase extends FormBase {
   protected $logger;
 
   /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
    * PoetryCheckoutForm constructor.
    *
    * @param \Drupal\oe_translation_poetry\PoetryJobQueueFactory $queueFactory
@@ -70,13 +78,16 @@ abstract class PoetryCheckoutFormBase extends FormBase {
    *   The content formatter.
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerChannelFactory
    *   The logger channel factory.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
    */
-  public function __construct(PoetryJobQueueFactory $queueFactory, Poetry $poetry, MessengerInterface $messenger, PoetryContentFormatterInterface $contentFormatter, LoggerChannelFactoryInterface $loggerChannelFactory) {
+  public function __construct(PoetryJobQueueFactory $queueFactory, Poetry $poetry, MessengerInterface $messenger, PoetryContentFormatterInterface $contentFormatter, LoggerChannelFactoryInterface $loggerChannelFactory, EntityTypeManagerInterface $entityTypeManager) {
     $this->queueFactory = $queueFactory;
     $this->poetry = $poetry;
     $this->messenger = $messenger;
     $this->contentFormatter = $contentFormatter;
     $this->logger = $loggerChannelFactory->get('oe_translation_poetry');
+    $this->entityTypeManager = $entityTypeManager;
   }
 
   /**
@@ -88,7 +99,8 @@ abstract class PoetryCheckoutFormBase extends FormBase {
       $container->get('oe_translation_poetry.client.default'),
       $container->get('messenger'),
       $container->get('oe_translation_poetry.html_formatter'),
-      $container->get('logger.factory')
+      $container->get('logger.factory'),
+      $container->get('entity_type.manager')
     );
   }
 

--- a/modules/oe_translation_poetry/src/Form/PoetryCheckoutFormBase.php
+++ b/modules/oe_translation_poetry/src/Form/PoetryCheckoutFormBase.php
@@ -10,11 +10,8 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Messenger\MessengerInterface;
-use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\Core\Url;
 use Drupal\oe_translation_poetry\Poetry;
 use Drupal\oe_translation_poetry\PoetryJobQueueFactory;
-use Drupal\oe_translation_poetry\PoetryTranslatorUI;
 use Drupal\oe_translation_poetry_html_formatter\PoetryContentFormatterInterface;
 use Drupal\tmgmt\JobInterface;
 use EC\Poetry\Messages\Responses\ResponseInterface;
@@ -117,7 +114,6 @@ abstract class PoetryCheckoutFormBase extends FormBase {
    *   The form structure.
    */
   public function buildForm(array $form, FormStateInterface $form_state, ContentEntityInterface $node = NULL) {
-    $translator_settings = $this->poetry->getTranslatorSettings();
 
     $form_state->set('entity', $node);
 
@@ -135,42 +131,6 @@ abstract class PoetryCheckoutFormBase extends FormBase {
       '#required' => TRUE,
       '#default_value' => (new \DateTime('+30 day'))->format('Y-m-d'),
       '#min' => (new \DateTime('today'))->format('Y-m-d'),
-    ];
-
-    $default_contact = $translator_settings['contact'] ?? [];
-    $form['details']['contact'] = [
-      '#type' => 'fieldset',
-      '#title' => $this->t('Contact information'),
-    ];
-
-    foreach (PoetryTranslatorUI::getContactFieldNames('contact') as $name => $label) {
-      $form['details']['contact'][$name] = [
-        '#type' => 'textfield',
-        '#title' => $label,
-        '#default_value' => $default_contact[$name] ?? '',
-        '#required' => TRUE,
-      ];
-    }
-
-    $default_organisation = $translator_settings['organisation'] ?? [];
-    $form['details']['organisation'] = [
-      '#type' => 'fieldset',
-      '#title' => $this->t('Organisation information'),
-    ];
-
-    foreach (PoetryTranslatorUI::getContactFieldNames('organisation') as $name => $label) {
-      $form['details']['organisation'][$name] = [
-        '#type' => 'textfield',
-        '#title' => $label,
-        '#default_value' => $default_organisation[$name] ?? '',
-        '#required' => TRUE,
-      ];
-    }
-
-    $form['details']['comment'] = [
-      '#type' => 'textarea',
-      '#title' => $this->t('Comment'),
-      '#description' => $this->t('Optional remark about the translation request.'),
     ];
 
     $form['actions'] = ['#type' => 'actions'];
@@ -208,143 +168,6 @@ abstract class PoetryCheckoutFormBase extends FormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     // The submit handler is submitRequest().
-  }
-
-  /**
-   * Returns the title of the form page.
-   *
-   * @param \Drupal\Core\Entity\ContentEntityInterface $node
-   *   The node entity to use when generating the title.
-   *
-   * @return \Drupal\Core\StringTranslation\TranslatableMarkup
-   *   The title for the form page.
-   */
-  public function getPageTitle(ContentEntityInterface $node = NULL): TranslatableMarkup {
-    $queue = $this->queueFactory->get($node);
-    $entity = $queue->getEntity();
-    $target_languages = $queue->getTargetLanguages();
-    $target_languages = count($target_languages) > 1 ? implode(', ', $target_languages) : array_shift($target_languages);
-    return $this->t('Send request to DG Translation for <em>@entity</em> in <em>@target_languages</em>', ['@entity' => $entity->label(), '@target_languages' => $target_languages]);
-  }
-
-  /**
-   * Submits the request to Poetry.
-   *
-   * @param array $form
-   *   The form.
-   * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *   The form state.
-   */
-  public function submitRequest(array &$form, FormStateInterface $form_state): void {
-    $entity = $form_state->get('entity');
-    $queue = $this->queueFactory->get($entity);
-    $translator_settings = $this->poetry->getTranslatorSettings();
-    $jobs = $queue->getAllJobs();
-    $identifier = $this->poetry->getIdentifierForContent($entity);
-    $identifier->setProduct($this->requestType);
-
-    $date = new \DateTime($form_state->getValue('details')['date']);
-    $formatted_date = $date->format('d/m/Y');
-
-    /** @var \EC\Poetry\Messages\Requests\CreateTranslationRequest $message */
-    $message = $this->poetry->get('request.create_translation_request');
-    $message->setIdentifier($identifier);
-
-    // Build the details.
-    $details = $message->withDetails();
-    $details->setDelay($formatted_date);
-
-    if ($form_state->getValue('details')['comment']) {
-      $details->setRemark($form_state->getValue('details')['comment']);
-    }
-
-    // We use the formatted identifier as the user reference.
-    $details->setClientId($identifier->getFormattedIdentifier());
-    $title = $this->createRequestTitle(reset($jobs));
-    $details->setTitle($title);
-    $details->setApplicationId($translator_settings['application_reference']);
-    $details->setReferenceFilesRemark($entity->toUrl()->setAbsolute()->toString());
-    $details
-      ->setProcedure('NEANT')
-      ->setDestination('PUBLIC')
-      ->setType('INTER');
-
-    // Add the organisation information.
-    $organisation_information = [
-      'setResponsible' => 'responsible',
-      'setAuthor' => 'author',
-      'setRequester' => 'requester',
-    ];
-    foreach ($organisation_information as $method => $name) {
-      $details->$method($form_state->getValue('details')['organisation'][$name]);
-    }
-
-    $message->setDetails($details);
-
-    // Build the contact information.
-    foreach (PoetryTranslatorUI::getContactFieldNames('contact') as $name => $label) {
-      $message->withContact()
-        ->setType($name)
-        ->setNickname($form_state->getValue('details')['contact'][$name]);
-    }
-
-    // Build the return endpoint information.
-    $settings = $this->poetry->getSettings();
-    $username = $settings['notification.username'] ?? NULL;
-    $password = $settings['notification.password'] ?? NULL;
-    $return = $message->withReturnAddress();
-    $return->setUser($username);
-    $return->setPassword($password);
-    // The notification endpoint WSDL.
-    $return->setAddress(Url::fromRoute('oe_translation_poetry.notifications')->setAbsolute()->toString() . '?wsdl');
-    // The notification endpoint WSDL action method.
-    $return->setPath('handle');
-    // The return is a webservice and not an email.
-    $return->setType('webService');
-    $return->setAction($this->getRequestOperation());
-    $message->setReturnAddress($return);
-
-    $source = $message->withSource();
-    $source->setFormat('HTML');
-    $source->setName('content.html');
-    $formatted_content = $this->contentFormatter->export(reset($jobs));
-    $source->setFile(base64_encode($formatted_content->__toString()));
-    $source->setLegiswriteFormat('No');
-    $source->withSourceLanguage()
-      ->setCode(strtoupper($entity->language()->getId()))
-      ->setPages(1);
-    $message->setSource($source);
-
-    foreach ($jobs as $job) {
-      $message->withTarget()
-        ->setLanguage(strtoupper($job->getRemoteTargetLanguage()))
-        ->setFormat('HTML')
-        ->setAction($this->getRequestOperation())
-        ->setDelay($formatted_date);
-    }
-
-    try {
-      $client = $this->poetry->getClient();
-      /** @var \EC\Poetry\Messages\Responses\ResponseInterface $response */
-      $response = $client->send($message);
-      $this->handlePoetryResponse($response, $form_state);
-
-      // If we request a new number by setting a sequence, update the global
-      // identifier number with the new number that came for future requests.
-      if ($identifier->getSequence()) {
-        $this->poetry->setGlobalIdentifierNumber($response->getIdentifier()->getNumber());
-      }
-
-      $this->redirectBack($form_state);
-      $queue->reset();
-      $this->messenger->addStatus($this->t('The request has been sent to DGT.'));
-    }
-    catch (\Exception $exception) {
-      $this->logger->error($exception->getMessage());
-      $this->messenger->addError($this->t('There was an error making the request to DGT.'));
-      $this->redirectBack($form_state);
-      $queue->reset();
-    }
   }
 
   /**

--- a/modules/oe_translation_poetry/src/Form/UpdateTranslationRequestForm.php
+++ b/modules/oe_translation_poetry/src/Form/UpdateTranslationRequestForm.php
@@ -13,13 +13,13 @@ use Drupal\oe_translation_poetry\PoetryTranslatorUI;
 /**
  * Form for requesting new translations.
  */
-class NewTranslationRequestForm extends PoetryCheckoutFormBase {
+class UpdateTranslationRequestForm extends PoetryCheckoutFormBase {
 
   /**
    * {@inheritdoc}
    */
   public function getFormId() {
-    return 'oe_translation_poetry_new_translation_request';
+    return 'oe_translation_poetry_create_translation_request';
   }
 
   /**
@@ -35,16 +35,16 @@ class NewTranslationRequestForm extends PoetryCheckoutFormBase {
     $queue = $this->queueFactory->get($node);
     $entity = $queue->getEntity();
     $target_languages = $queue->getTargetLanguages();
-    $target_languages = implode(', ', $target_languages);
-    return $this->t('Send request to DG Translation for <em>@entity</em> in <em>@target_languages</em>', ['@entity' => $entity->label(), '@target_languages' => $target_languages]);
+    $target_languages = implode(', ', $target_languages)  ;
+    return $this->t('Send request update to DG Translation for <em>@entity</em> in <em>@target_languages</em>', ['@entity' => $entity->label(), '@target_languages' => $target_languages]);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, ContentEntityInterface $node = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state) {
     $translator_settings = $this->poetry->getTranslatorSettings();
-    $form = parent::buildForm($form, $form_state, $node);
+    $form = parent::buildForm($form, $form_state);
 
     $default_contact = $translator_settings['contact'] ?? [];
     $form['details']['contact'] = [

--- a/modules/oe_translation_poetry/src/Form/UpdateTranslationRequestForm.php
+++ b/modules/oe_translation_poetry/src/Form/UpdateTranslationRequestForm.php
@@ -117,13 +117,6 @@ class UpdateTranslationRequestForm extends NewTranslationRequestForm {
   }
 
   /**
-   * {@inheritdoc}
-   */
-  protected function getRequestOperation(): string {
-    return 'INSERT';
-  }
-
-  /**
    * Get active jobs of an entity.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity

--- a/modules/oe_translation_poetry/src/Form/UpdateTranslationRequestForm.php
+++ b/modules/oe_translation_poetry/src/Form/UpdateTranslationRequestForm.php
@@ -87,7 +87,11 @@ class UpdateTranslationRequestForm extends NewTranslationRequestForm {
     /** @var \Drupal\tmgmt\JobItemInterface[] $job_items */
     $job_items = $this->entityTypeManager->getStorage('tmgmt_job_item')->loadMultiple($ids);
     foreach ($job_items as $job_item) {
-      $jobs[] = $job_item->getJob();
+      $job = $job_item->getJob();
+      if ($job->getTranslatorId() !== 'poetry') {
+        continue;
+      }
+      $jobs[] = $job;
     }
 
     return $jobs;

--- a/modules/oe_translation_poetry/src/Form/UpdateTranslationRequestForm.php
+++ b/modules/oe_translation_poetry/src/Form/UpdateTranslationRequestForm.php
@@ -107,8 +107,8 @@ class UpdateTranslationRequestForm extends NewTranslationRequestForm {
 
     parent::submitRequest($form, $form_state);
 
-    // Abort active jobs for this entity.
-    $jobs = $this->getAllJobsForEntity($entity);
+    // Abort non queued active jobs for this entity.
+    $jobs = $this->getActiveJobsForEntity($entity);
     foreach ($jobs as $job) {
       if (!in_array($job->id(), $queued_jobs)) {
         $job->aborted('Job aborted after update request.');
@@ -132,7 +132,7 @@ class UpdateTranslationRequestForm extends NewTranslationRequestForm {
    * @return \Drupal\tmgmt\JobInterface[]
    *   The active jobs.
    */
-  protected function getAllJobsForEntity(EntityInterface $entity): array {
+  protected function getActiveJobsForEntity(EntityInterface $entity): array {
     $ids = $this->entityTypeManager->getStorage('tmgmt_job_item')->getQuery()
       ->condition('item_type', $entity->getEntityType()->id())
       ->condition('item_id', $entity->id())

--- a/modules/oe_translation_poetry/src/Form/UpdateTranslationRequestForm.php
+++ b/modules/oe_translation_poetry/src/Form/UpdateTranslationRequestForm.php
@@ -6,67 +6,14 @@ namespace Drupal\oe_translation_poetry\Form;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\oe_translation_poetry\Poetry;
-use Drupal\oe_translation_poetry\PoetryJobQueueFactory;
-use Drupal\oe_translation_poetry_html_formatter\PoetryContentFormatterInterface;
 use Drupal\tmgmt\Entity\JobItem;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Form for requesting translations updates.
  */
 class UpdateTranslationRequestForm extends NewTranslationRequestForm {
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * PoetryCheckoutForm constructor.
-   *
-   * @param \Drupal\oe_translation_poetry\PoetryJobQueueFactory $queueFactory
-   *   The job queue factory.
-   * @param \Drupal\oe_translation_poetry\Poetry $poetry
-   *   The Poetry client.
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
-   *   The messenger service.
-   * @param \Drupal\oe_translation_poetry_html_formatter\PoetryContentFormatterInterface $contentFormatter
-   *   The content formatter.
-   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerChannelFactory
-   *   The logger channel factory.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager.
-   */
-  public function __construct(PoetryJobQueueFactory $queueFactory, Poetry $poetry, MessengerInterface $messenger, PoetryContentFormatterInterface $contentFormatter, LoggerChannelFactoryInterface $loggerChannelFactory, EntityTypeManagerInterface $entityTypeManager) {
-    $this->queueFactory = $queueFactory;
-    $this->poetry = $poetry;
-    $this->messenger = $messenger;
-    $this->contentFormatter = $contentFormatter;
-    $this->logger = $loggerChannelFactory->get('oe_translation_poetry');
-    $this->entityTypeManager = $entityTypeManager;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('oe_translation_poetry.job_queue_factory'),
-      $container->get('oe_translation_poetry.client.default'),
-      $container->get('messenger'),
-      $container->get('oe_translation_poetry.html_formatter'),
-      $container->get('logger.factory'),
-      $container->get('entity_type.manager')
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/oe_translation_poetry/src/Form/UpdateTranslationRequestForm.php
+++ b/modules/oe_translation_poetry/src/Form/UpdateTranslationRequestForm.php
@@ -11,7 +11,7 @@ use Drupal\Core\Url;
 use Drupal\oe_translation_poetry\PoetryTranslatorUI;
 
 /**
- * Form for requesting new translations.
+ * Form for requesting translations updates.
  */
 class UpdateTranslationRequestForm extends PoetryCheckoutFormBase {
 
@@ -19,7 +19,7 @@ class UpdateTranslationRequestForm extends PoetryCheckoutFormBase {
    * {@inheritdoc}
    */
   public function getFormId() {
-    return 'oe_translation_poetry_create_translation_request';
+    return 'oe_translation_poetry_update_translation_request';
   }
 
   /**
@@ -35,16 +35,16 @@ class UpdateTranslationRequestForm extends PoetryCheckoutFormBase {
     $queue = $this->queueFactory->get($node);
     $entity = $queue->getEntity();
     $target_languages = $queue->getTargetLanguages();
-    $target_languages = implode(', ', $target_languages)  ;
-    return $this->t('Send request update to DG Translation for <em>@entity</em> in <em>@target_languages</em>', ['@entity' => $entity->label(), '@target_languages' => $target_languages]);
+    $target_languages = implode(', ', $target_languages);
+    return $this->t('Send update request to DG Translation for <em>@entity</em> in <em>@target_languages</em>', ['@entity' => $entity->label(), '@target_languages' => $target_languages]);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state) {
+  public function buildForm(array $form, FormStateInterface $form_state, ContentEntityInterface $node = NULL) {
     $translator_settings = $this->poetry->getTranslatorSettings();
-    $form = parent::buildForm($form, $form_state);
+    $form = parent::buildForm($form, $form_state, $node);
 
     $default_contact = $translator_settings['contact'] ?? [];
     $form['details']['contact'] = [

--- a/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
+++ b/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
@@ -637,7 +637,7 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
    * @return array
    *   An array of completed job IDs, keyed by the target language.
    */
-  protected function getCompletedJobsByLanguage(ContentEntityInterface $entity, \stdClass $job_info): array {
+  protected function getCompletedJobsByLanguage(ContentEntityInterface $entity, $job_info): array {
     $query = $this->getEntityJobsQuery($entity);
     $job = $this->entityTypeManager->getStorage('tmgmt_job')->load($job_info->tjid);
     $reference = $job->get('poetry_request_id')->first()->getValue();

--- a/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
+++ b/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
@@ -228,19 +228,6 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
     $collection = new RouteCollection();
 
     $route = new Route(
-      '/admin/content/dgt/send-request/{node}',
-      [
-        '_form' => '\Drupal\oe_translation_poetry\Form\NewTranslationRequestForm',
-        '_title_callback' => '\Drupal\oe_translation_poetry\Form\NewTranslationRequestForm::getPageTitle',
-      ],
-      [
-        '_permission' => 'translate any entity',
-        '_custom_access' => 'oe_translation_poetry.job_queue_factory::access',
-      ]
-    );
-    $collection->add('oe_translation_poetry.job_queue_checkout', $route);
-
-    $route = new Route(
       '/admin/content/dgt/send-request-new/{node}',
       [
         '_form' => '\Drupal\oe_translation_poetry\Form\NewTranslationRequestForm',
@@ -505,10 +492,10 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
       $this->request->query->remove('destination');
     }
 
-    $route = 'oe_translation_poetry.job_queue_checkout';
+    $route = 'oe_translation_poetry.job_queue_checkout_new';
     $accepted_languages = $this->getAcceptedJobsByLanguage($entity);
     if (!empty($accepted_languages)) {
-      $route = 'oe_translation_poetry.job_queue_checkout';
+      $route = 'oe_translation_poetry.job_queue_checkout_update';
     }
     $redirect = Url::fromRoute($route, ['node' => $entity->id()]);
 

--- a/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
+++ b/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
@@ -228,6 +228,19 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
     $collection = new RouteCollection();
 
     $route = new Route(
+      '/admin/content/dgt/send-request/{node}',
+      [
+        '_form' => '\Drupal\oe_translation_poetry\Form\NewTranslationRequestForm',
+        '_title_callback' => '\Drupal\oe_translation_poetry\Form\NewTranslationRequestForm::getPageTitle',
+      ],
+      [
+        '_permission' => 'translate any entity',
+        '_custom_access' => 'oe_translation_poetry.job_queue_factory::access',
+      ]
+    );
+    $collection->add('oe_translation_poetry.job_queue_checkout', $route);
+
+    $route = new Route(
       '/admin/content/dgt/send-request-new/{node}',
       [
         '_form' => '\Drupal\oe_translation_poetry\Form\NewTranslationRequestForm',
@@ -239,6 +252,19 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
       ]
     );
     $collection->add('oe_translation_poetry.job_queue_checkout_new', $route);
+
+    $route = new Route(
+      '/admin/content/dgt/send-request-update/{node}',
+      [
+        '_form' => '\Drupal\oe_translation_poetry\Form\UpdateTranslationRequestForm',
+        '_title_callback' => '\Drupal\oe_translation_poetry\Form\UpdateTranslationRequestForm::getPageTitle',
+      ],
+      [
+        '_permission' => 'translate any entity',
+        '_custom_access' => 'oe_translation_poetry.job_queue_factory::access',
+      ]
+    );
+    $collection->add('oe_translation_poetry.job_queue_checkout_update', $route);
 
     $route = new Route(
       '/poetry/notifications',
@@ -479,12 +505,12 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
       $this->request->query->remove('destination');
     }
 
-    $route = 'oe_translation_poetry.job_queue_checkout_new';
+    $route = 'oe_translation_poetry.job_queue_checkout';
     $accepted_languages = $this->getAcceptedJobsByLanguage($entity);
     if (!empty($accepted_languages)) {
-      $route = 'oe_translation_poetry.job_queue_checkout_update';
+      $route = 'oe_translation_poetry.job_queue_checkout';
     }
-    $redirect = Url::fromRoute($route);
+    $redirect = Url::fromRoute($route, ['node' => $entity->id()]);
 
     // Redirect to the checkout form.
     $form_state->setRedirectUrl($redirect);

--- a/modules/oe_translation_poetry/src/Poetry.php
+++ b/modules/oe_translation_poetry/src/Poetry.php
@@ -283,7 +283,7 @@ class Poetry implements PoetryInterface {
    * @return \EC\Poetry\Messages\Components\Identifier
    *   The identifier.
    */
-  protected function getLastIdentifierForContent(ContentEntityInterface $entity): ?Identifier {
+  public function getLastIdentifierForContent(ContentEntityInterface $entity): ?Identifier {
     $query = $this->database->select('tmgmt_job', 'job');
     $query->join('tmgmt_job_item', 'job_item', 'job.tjid = job_item.tjid');
     $query->fields('job');

--- a/modules/oe_translation_poetry/src/PoetryJobQueue.php
+++ b/modules/oe_translation_poetry/src/PoetryJobQueue.php
@@ -133,6 +133,21 @@ class PoetryJobQueue {
   }
 
   /**
+   * Returns the ids of all jobs in the queue.
+   *
+   * @return array
+   *   The ids of the jobs.
+   */
+  public function getAllJobsIds(): array {
+    $queue = $this->initializeQueue();
+    if (!$queue['jobs']) {
+      return [];
+    }
+
+    return $queue['jobs'];
+  }
+
+  /**
    * Sets the destination URL.
    *
    * @param \Drupal\Core\Url $url

--- a/modules/oe_translation_poetry/src/PoetryRequestType.php
+++ b/modules/oe_translation_poetry/src/PoetryRequestType.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Drupal\oe_translation_poetry;
+
+/**
+ * Represents a request type that can be made to Poetry.
+ */
+class PoetryRequestType {
+
+  /**
+   * Indicates a request for a new translation for an entity.
+   */
+  const NEW = 'NEW';
+
+  /**
+   * Indicates a request for an update of a  translation for an entity.
+   */
+  const UPDATE = 'UPDATE';
+
+  /**
+   * The reason for the request type.
+   *
+   * @var string|null
+   */
+  protected $message = NULL;
+
+  /**
+   * The request type.
+   *
+   * @var string
+   */
+  protected $requestType = self::NEW;
+
+  /**
+   * PoetryRequestType constructor.
+   *
+   * @param string $requestType
+   *   The default request type.
+   */
+  public function __construct(string $requestType) {
+    $this->requestType = $requestType;
+    $this->message = NULL;
+  }
+
+  /**
+   * Returns the reason for the request type.
+   *
+   * @return string|null
+   *   The message.
+   */
+  public function getMessage(): ?string {
+    return $this->message;
+  }
+
+  /**
+   * Sets the reason for the request type.
+   *
+   * @param string $message
+   *   The reason.
+   */
+  public function setMessage(string $message): void {
+    $this->message = $message;
+  }
+
+  /**
+   * Returns the request type.
+   *
+   * @return string
+   *   The request type.
+   */
+  public function getType(): string {
+    return $this->requestType;
+  }
+
+  /**
+   * Sets the request type.
+   *
+   * @param string $requestType
+   *   The request type.
+   */
+  public function setRequestType(string $requestType): void {
+    $this->requestType = $requestType;
+    $this->message = NULL;
+  }
+
+}

--- a/modules/oe_translation_poetry/src/PoetryTranslatorUI.php
+++ b/modules/oe_translation_poetry/src/PoetryTranslatorUI.php
@@ -97,7 +97,7 @@ class PoetryTranslatorUI extends TranslatorPluginUiBase {
 
     if ($poetry_state === PoetryTranslator::POETRY_STATUS_ONGOING) {
       $build[] = [
-        '#markup' => $this->t('This job is being translated in Poetry'),
+        '#markup' => $this->t('This job is being translated in Poetry.'),
       ];
     }
 

--- a/modules/oe_translation_poetry/tests/Functional/PoetryConfigurationTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryConfigurationTest.php
@@ -148,7 +148,7 @@ class PoetryConfigurationTest extends PoetryTranslationTestBase {
     $node->save();
 
     $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
-    $this->assertSession()->buttonExists('Request DGT translation for the selected languages');
+    $this->assertSession()->buttonExists('Request a DGT translation for the selected languages');
 
     // Unset the service WSDL as an example of required configuration.
     /** @var \Drupal\tmgmt\TranslatorInterface $translator */
@@ -157,7 +157,7 @@ class PoetryConfigurationTest extends PoetryTranslationTestBase {
     $translator->save();
 
     $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
-    $this->assertSession()->buttonNotExists('Request DGT translation for the selected languages');
+    $this->assertSession()->buttonNotExists('Request a DGT translation for the selected languages');
   }
 
 }

--- a/modules/oe_translation_poetry/tests/Functional/PoetryNotificationTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryNotificationTest.php
@@ -17,7 +17,7 @@ class PoetryNotificationTest extends PoetryTranslationTestBase {
    * Tests the handling of Poetry status notifications.
    */
   public function testStatusNotifications(): void {
-    $this->prepareRequestedJobs([
+    $this->createNodeWithRequestedJobs([
       'title' => 'My node title',
       'field_oe_demo_translatable_body' => 'My node body',
     ], ['fr', 'pt-pt', 'it']);
@@ -102,7 +102,7 @@ class PoetryNotificationTest extends PoetryTranslationTestBase {
    * Tests the handling of Poetry translation notifications.
    */
   public function testTranslationNotifications(): void {
-    $this->prepareRequestedJobs([
+    $this->createNodeWithRequestedJobs([
       'title' => 'My node title',
       'field_oe_demo_translatable_body' => 'My node body',
     ], ['fr', 'es']);
@@ -149,7 +149,7 @@ class PoetryNotificationTest extends PoetryTranslationTestBase {
    * Tests the access on the notification endpoint.
    */
   public function testNotificationEndpointAccess(): void {
-    $this->prepareRequestedJobs([
+    $this->createNodeWithRequestedJobs([
       'title' => 'My node title',
       'field_oe_demo_translatable_body' => 'My node body',
     ], ['fr', 'de', 'it']);
@@ -185,47 +185,6 @@ class PoetryNotificationTest extends PoetryTranslationTestBase {
 
     // Load the jobs and assert that nothing happened because the access was
     // denied.
-    $this->jobStorage->resetCache();
-    /** @var \Drupal\tmgmt\JobInterface[] $jobs */
-    $jobs = $this->jobStorage->loadMultiple();
-    foreach ($jobs as $job) {
-      $this->assertTrue($job->get('poetry_request_date_updated')->isEmpty());
-      $this->assertTrue($job->get('poetry_state')->isEmpty());
-    }
-  }
-
-  /**
-   * Creates jobs that mimic a request having been made to Poetry.
-   *
-   * @param array $values
-   *   The content values.
-   * @param array $languages
-   *   The job languages.
-   */
-  protected function prepareRequestedJobs(array $values, array $languages = []): void {
-    /** @var \Drupal\node\NodeStorageInterface $node_storage */
-    $node_storage = $this->entityTypeManager->getStorage('node');
-
-    /** @var \Drupal\node\NodeInterface $node */
-    $node = $node_storage->create([
-      'type' => 'page',
-    ] + $values);
-    $node->save();
-
-    // Create a job for French and German to mimic that the request has been
-    // made to Poetry.
-    foreach ($languages as $language) {
-      $job = tmgmt_job_create('en', $language, 0);
-      $job->translator = 'poetry';
-      $job->addItem('content', 'node', $node->id());
-      $job->set('poetry_request_id', $this->defaultIdentifierInfo);
-      $job->set('state', Job::STATE_ACTIVE);
-      $date = new \DateTime('05/04/2019');
-      $job->set('poetry_request_date', $date->format('Y-m-d\TH:i:s'));
-      $job->save();
-    }
-
-    // Ensure the jobs do not contain any info related to Poetry status.
     $this->jobStorage->resetCache();
     /** @var \Drupal\tmgmt\JobInterface[] $jobs */
     $jobs = $this->jobStorage->loadMultiple();

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
@@ -28,7 +28,7 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
     $node->save();
 
     // Assert we can't access the checkout route without jobs in the queue.
-    $this->drupalGet(Url::fromRoute('oe_translation_poetry.job_queue_checkout', ['node' => $node->id()]));
+    $this->drupalGet(Url::fromRoute('oe_translation_poetry.job_queue_checkout_new', ['node' => $node->id()]));
     $this->assertSession()->statusCodeEquals(403);
 
     // Select some languages to translate.

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
@@ -184,7 +184,7 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
     $this->submitTranslationRequestForQueue($node_three);
     $this->jobStorage->resetCache();
 
-    // The jobs should have gotten submitted and the identification numbers
+    // The jobs shouqld have gotten submitted and the identification numbers
     // set.
     $expected_poetry_request_id = [
       'code' => 'WEB',
@@ -223,7 +223,7 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
     $this->assertSession()->buttonExists('Request DGT translation for the selected languages');
     // Assert that each node has its own queue by trying to access the checkout
     // of the second node (which has no pending jobs).
-    $this->drupalGet(Url::fromRoute('oe_translation_poetry.job_queue_checkout', ['node' => $second_node->id()]));
+    $this->drupalGet(Url::fromRoute('oe_translation_poetry.job_queue_checkout_new', ['node' => $second_node->id()]));
     $this->assertSession()->statusCodeEquals(403);
 
     // Go back to the translation overview to mimic that the user did not

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
@@ -220,7 +220,7 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
 
     // Assert that the second node doesn't have any pending jobs.
     $this->drupalGet($second_node->toUrl('drupal:content-translation-overview'));
-    $this->assertSession()->buttonExists('Request DGT translation for the selected languages');
+    $this->assertSession()->buttonExists('Request a DGT translation for the selected languages');
     // Assert that each node has its own queue by trying to access the checkout
     // of the second node (which has no pending jobs).
     $this->drupalGet(Url::fromRoute('oe_translation_poetry.job_queue_checkout_new', ['node' => $second_node->id()]));

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
@@ -184,7 +184,7 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
     $this->submitTranslationRequestForQueue($node_three);
     $this->jobStorage->resetCache();
 
-    // The jobs shouqld have gotten submitted and the identification numbers
+    // The jobs should have gotten submitted and the identification numbers
     // set.
     $expected_poetry_request_id = [
       'code' => 'WEB',

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationTestBase.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationTestBase.php
@@ -9,6 +9,7 @@ use Drupal\node\NodeInterface;
 use Drupal\oe_translation_poetry_mock\PoetryMock;
 use Drupal\Tests\oe_translation\Functional\TranslationTestBase;
 use Drupal\Tests\oe_translation_poetry\Traits\PoetryTestTrait;
+use Drupal\tmgmt\Entity\Job;
 
 /**
  * Base class for functional tests of the Poetry integration.
@@ -116,6 +117,77 @@ class PoetryTranslationTestBase extends TranslationTestBase {
 
     $this->drupalPostForm($node->toUrl('drupal:content-translation-overview'), $values, 'Request DGT translation for the selected languages');
     $this->assertSession()->pageTextContains($expected_title->__toString());
+  }
+
+  /**
+   * Creates jobs that mimic a request having been made to Poetry.
+   *
+   * @param array $values
+   *   The content values.
+   * @param array $languages
+   *   The job languages.
+   *
+   * @return \Drupal\node\NodeInterface
+   *   The created node.
+   */
+  protected function createNodeWithRequestedJobs(array $values, array $languages = []): NodeInterface {
+    /** @var \Drupal\node\NodeStorageInterface $node_storage */
+    $node_storage = $this->entityTypeManager->getStorage('node');
+
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $node_storage->create([
+      'type' => 'page',
+    ] + $values);
+    $node->save();
+
+    // Create a job for given languages to mimic that the request has been
+    // made to Poetry.
+    foreach ($languages as $language) {
+      $job = tmgmt_job_create('en', $language, 0);
+      $job->translator = 'poetry';
+      $job->addItem('content', 'node', $node->id());
+      $job->set('poetry_request_id', $this->defaultIdentifierInfo);
+      $job->set('state', Job::STATE_ACTIVE);
+      $date = new \DateTime('05/04/2019');
+      $job->set('poetry_request_date', $date->format('Y-m-d\TH:i:s'));
+      $job->save();
+    }
+
+    // Ensure the jobs do not contain any info related to Poetry status.
+    $this->jobStorage->resetCache();
+    /** @var \Drupal\tmgmt\JobInterface[] $jobs */
+    $jobs = $this->jobStorage->loadMultiple();
+    foreach ($jobs as $job) {
+      $this->assertTrue($job->get('poetry_request_date_updated')->isEmpty());
+      $this->assertTrue($job->get('poetry_state')->isEmpty());
+    }
+
+    return $node;
+  }
+
+  /**
+   * Submits the request in queue.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node.
+   */
+  protected function submitRequestInQueue(NodeInterface $node): void {
+    // Submit the request form.
+    $date = new \DateTime();
+    $date->modify('+ 7 days');
+    $values = [
+      'details[date]' => $date->format('Y-m-d'),
+      'details[contact][auteur]' => 'userid',
+      'details[contact][secretaire]' => 'userid',
+      'details[contact][contact]' => 'userid',
+      'details[contact][responsable]' => 'userid',
+      'details[organisation][responsible]' => 'DIGIT',
+      'details[organisation][author]' => 'IE/CE/DIGIT',
+      'details[organisation][requester]' => 'IE/CE/DIGIT',
+    ];
+    $this->drupalPostForm(NULL, $values, 'Send request');
+    $this->assertSession()->pageTextContains('The request has been sent to DGT.');
+    $this->assertSession()->addressEquals('/en/node/' . $node->id() . '/translations');
   }
 
 }

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationTestBase.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationTestBase.php
@@ -43,7 +43,7 @@ class PoetryTranslationTestBase extends TranslationTestBase {
     'version' => '0',
     'product' => 'TRA',
     'number' => 3234,
-    'year' => 2010,
+    'year' => 2020,
   ];
 
   /**
@@ -79,6 +79,8 @@ class PoetryTranslationTestBase extends TranslationTestBase {
 
   /**
    * Groups the jobs by their target language.
+   *
+   * It returns only the latest jobs for each language.
    *
    * @param \Drupal\tmgmt\JobInterface[] $jobs
    *   The jobs.

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationTestBase.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationTestBase.php
@@ -117,7 +117,7 @@ class PoetryTranslationTestBase extends TranslationTestBase {
     $target_languages = count($languages) > 1 ? implode(', ', $languages) : array_shift($languages);
     $expected_title = new FormattableMarkup('Send request to DG Translation for @entity in @target_languages', ['@entity' => $node->label(), '@target_languages' => $target_languages]);
 
-    $this->drupalPostForm($node->toUrl('drupal:content-translation-overview'), $values, 'Request DGT translation for the selected languages');
+    $this->drupalPostForm($node->toUrl('drupal:content-translation-overview'), $values, 'Request a DGT translation for the selected languages');
     $this->assertSession()->pageTextContains($expected_title->__toString());
   }
 

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationUpdateRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationUpdateRequestTest.php
@@ -89,7 +89,7 @@ class PoetryTranslationUpdateRequestTest extends PoetryTranslationTestBase {
     // Assert we can not see operation buttons again.
     $this->assertSession()->buttonNotExists('Request a DGT translation for the selected languages');
     $this->assertSession()->buttonNotExists('Request a DGT translation update for the selected languages');
-    $this->assertSession()->pageTextContains('No translation requests can be made until the ongoing ones have been accepted and/or translated.');
+    $this->assertSession()->pageTextContains('No translation requests to DGT can be made until the ongoing ones have been accepted and/or translated.');
 
     // Send a status update accepting the translation for requested languages.
     // We need to increment the version because we already made one update
@@ -127,7 +127,7 @@ class PoetryTranslationUpdateRequestTest extends PoetryTranslationTestBase {
     }
 
     // Assert we see operation buttons again.
-    $this->assertSession()->pageTextNotContains('No translation requests can be made until the ongoing ones have been accepted and/or translated.');
+    $this->assertSession()->pageTextNotContains('No translation requests to DGT can be made until the ongoing ones have been accepted and/or translated.');
     $this->assertSession()->buttonNotExists('Request a DGT translation for the selected languages');
     $this->assertSession()->buttonExists('Request a DGT translation update for the selected languages');
 

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationUpdateRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationUpdateRequestTest.php
@@ -89,7 +89,7 @@ class PoetryTranslationUpdateRequestTest extends PoetryTranslationTestBase {
     // Assert we can not see operation buttons again.
     $this->assertSession()->buttonNotExists('Request a DGT translation for the selected languages');
     $this->assertSession()->buttonNotExists('Request a DGT translation update for the selected languages');
-    $this->assertSession()->pageTextContains('No translation requests can be made until the ongoing ones have been accepted.');
+    $this->assertSession()->pageTextContains('No translation requests can be made until the ongoing ones have been accepted and/or translated.');
 
     // Send a status update accepting the translation for requested languages.
     // We need to increment the version because we already made one update
@@ -127,7 +127,7 @@ class PoetryTranslationUpdateRequestTest extends PoetryTranslationTestBase {
     }
 
     // Assert we see operation buttons again.
-    $this->assertSession()->pageTextNotContains('No translation requests can be made until the ongoing ones have been accepted.');
+    $this->assertSession()->pageTextNotContains('No translation requests can be made until the ongoing ones have been accepted and/or translated.');
     $this->assertSession()->buttonNotExists('Request a DGT translation for the selected languages');
     $this->assertSession()->buttonExists('Request a DGT translation update for the selected languages');
 

--- a/modules/oe_translation_poetry/tests/Functional/PoetryUpdateRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryUpdateRequestTest.php
@@ -51,17 +51,19 @@ class PoetryUpdateRequestTest extends PoetryTranslationTestBase {
 
     $page = $this->getSession()->getPage();
     $page->checkField('edit-languages-de');
-    $this->drupalPostForm(NULL, [], 'Request a translation update');
+    $this->drupalPostForm(NULL, [], 'Request a translation update to all selected languages');
     $this->submitRequestInQueue($node);
     $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
 
-    // Check that the jobs have been correctly updated.
+    // Check that all jobs have been correctly updated.
     $this->jobStorage->resetCache();
-    /** @var \Drupal\tmgmt\JobInterface[] $jobs */
-    $jobs = $this->indexJobsByLanguage($this->jobStorage->loadMultiple());
-    $this->assertEqual($jobs['bg']->getState(), Job::STATE_ABORTED);
-    $this->assertEqual($jobs['cs']->getState(), Job::STATE_ABORTED);
-    $this->assertEqual($jobs['de']->getState(), Job::STATE_ACTIVE);
+    $old_jobs = $this->indexJobsByLanguage($this->jobStorage->loadMultiple([$jobs['bg']->id(), $jobs['cs']->id()]));
+    $this->assertEqual($old_jobs['bg']->getState(), Job::STATE_ABORTED);
+    $this->assertEqual($old_jobs['cs']->getState(), Job::STATE_ABORTED);
+    $new_jobs = $this->indexJobsByLanguage($this->jobStorage->loadMultiple());
+    $this->assertEqual($new_jobs['bg']->getState(), Job::STATE_ACTIVE);
+    $this->assertEqual($new_jobs['cs']->getState(), Job::STATE_ACTIVE);
+    $this->assertEqual($new_jobs['de']->getState(), Job::STATE_ACTIVE);
 
     // Assert we can not see operation buttons again.
     $this->assertSession()->buttonNotExists('Request DGT translation for the selected languages');

--- a/modules/oe_translation_poetry/tests/Functional/PoetryUpdateRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryUpdateRequestTest.php
@@ -23,7 +23,7 @@ class PoetryUpdateRequestTest extends PoetryTranslationTestBase {
     $this->assertSession()->pageTextContains('Translations of ' . $node->label());
     // Assert we can not see operation buttons.
     $this->assertSession()->buttonNotExists('Request DGT translation for the selected languages');
-    $this->assertSession()->buttonNotExists('Request a translation update');
+    $this->assertSession()->buttonNotExists('Request a translation update to all selected languages');
     // Send a status update accepting the translation for requested languages.
     $status_notification = $this->fixtureGenerator->statusNotification($this->defaultIdentifierInfo, 'ONG',
       [

--- a/modules/oe_translation_poetry/tests/Functional/PoetryUpdateRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryUpdateRequestTest.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types = 1);
+namespace Drupal\Tests\oe_translation_poetry\Functional;
+use Drupal\node\NodeInterface;
+use Drupal\tmgmt\Entity\Job;
+
+/**
+ * Tests adding languages to requests made to Poetry.
+ */
+class PoetryUpdateRequestTest extends PoetryTranslationTestBase {
+  /**
+   * Tests requesting a translation update.
+   */
+  public function testUpdateRequestRequest(): void {
+    $node = $this->createNodeWithRequestedJobs([
+      'title' => 'My node title',
+      'field_oe_demo_translatable_body' => 'My node body',
+    ], ['bg', 'cs']);
+    $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
+    $this->assertSession()->pageTextContains('Translations of ' . $node->label());
+    // Assert we can not see operation buttons.
+    $this->assertSession()->buttonNotExists('Request DGT translation for the selected languages');
+    $this->assertSession()->buttonNotExists('Request a translation update');
+    // Send a status update accepting the translation for requested languages.
+    $status_notification = $this->fixtureGenerator->statusNotification($this->defaultIdentifierInfo, 'ONG',
+      [
+        [
+          'code' => 'BG',
+          'date' => '05/10/2019 23:59',
+          'accepted_date' => '05/10/2020 23:59',
+        ],
+        [
+          'code' => 'CS',
+          'date' => '05/10/2019 23:59',
+          'accepted_date' => '05/10/2020 23:59',
+        ],
+      ]);
+    $this->performNotification($status_notification);
+    // Refresh page.
+    $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
+
+    // Check that the jobs have been correctly updated.
+    $this->jobStorage->resetCache();
+    /** @var \Drupal\tmgmt\JobInterface[] $jobs */
+    $jobs = $this->indexJobsByLanguage($this->jobStorage->loadMultiple());
+    $this->assertEqual($jobs['bg']->getState(), Job::STATE_ACTIVE);
+    $this->assertEqual($jobs['cs']->getState(), Job::STATE_ACTIVE);
+
+    $page = $this->getSession()->getPage();
+    $page->checkField('edit-languages-de');
+    $this->drupalPostForm(NULL, [], 'Request a translation update');
+    $this->submitRequestInQueue($node);
+    $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
+
+    // Check that the jobs have been correctly updated.
+    $this->jobStorage->resetCache();
+    /** @var \Drupal\tmgmt\JobInterface[] $jobs */
+    $jobs = $this->indexJobsByLanguage($this->jobStorage->loadMultiple());
+    $this->assertEqual($jobs['bg']->getState(), Job::STATE_ABORTED);
+    $this->assertEqual($jobs['cs']->getState(), Job::STATE_ABORTED);
+    $this->assertEqual($jobs['de']->getState(), Job::STATE_ACTIVE);
+
+    // Assert we can not see operation buttons again.
+    $this->assertSession()->buttonNotExists('Request DGT translation for the selected languages');
+    $this->assertSession()->pageTextContains('No translation requests can be made until the ongoing ones have been accepted.');
+  }
+}

--- a/modules/oe_translation_poetry/tests/Functional/PoetryUpdateRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryUpdateRequestTest.php
@@ -1,13 +1,16 @@
 <?php
+
 declare(strict_types = 1);
+
 namespace Drupal\Tests\oe_translation_poetry\Functional;
-use Drupal\node\NodeInterface;
+
 use Drupal\tmgmt\Entity\Job;
 
 /**
  * Tests adding languages to requests made to Poetry.
  */
 class PoetryUpdateRequestTest extends PoetryTranslationTestBase {
+
   /**
    * Tests requesting a translation update.
    */
@@ -64,4 +67,5 @@ class PoetryUpdateRequestTest extends PoetryTranslationTestBase {
     $this->assertSession()->buttonNotExists('Request DGT translation for the selected languages');
     $this->assertSession()->pageTextContains('No translation requests can be made until the ongoing ones have been accepted.');
   }
+
 }

--- a/modules/oe_translation_poetry/tests/Traits/PoetryTestTrait.php
+++ b/modules/oe_translation_poetry/tests/Traits/PoetryTestTrait.php
@@ -66,6 +66,8 @@ trait PoetryTestTrait {
    *
    * @param \Drupal\tmgmt\JobInterface[] $jobs
    *   The jobs.
+   *
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
    */
   protected function notifyWithDummyTranslations(array $jobs): void {
     // Prepare the identifier.

--- a/oe_translation.module
+++ b/oe_translation.module
@@ -47,7 +47,7 @@ function oe_translation_form_tmgmt_local_task_item_edit_form_alter(&$form, FormS
   $job = $task_item->getJobItem()->getJob();
   try {
     $translator_plugin = \Drupal::service('plugin.manager.tmgmt.translator')->createInstance($job->getTranslator()->getPluginId());
-    if ($translator_plugin instanceof AlterableTranslatorInterface) {
+    if ($translator_plugin instanceof LocalTranslatorInterface) {
       $translator_plugin->localTaskItemFormAlter($form, $form_state);
     }
   }

--- a/tests/Behat/PoetryTranslationContext.php
+++ b/tests/Behat/PoetryTranslationContext.php
@@ -139,6 +139,7 @@ class PoetryTranslationContext extends RawDrupalContext {
     $node = $this->getNodeByTitle($title);
     $query = $this->getEntityJobsQuery($node);
     $query->condition('job.target_language', array_keys($languages), 'IN');
+    $query->condition('job.state', Job::STATE_ACTIVE);
     $query->isNull('job.poetry_state');
     $result = $query->execute()->fetchAllAssoc('tjid');
     $jobs = Job::loadMultiple(array_keys($result));

--- a/tests/Behat/PoetryTranslationContext.php
+++ b/tests/Behat/PoetryTranslationContext.php
@@ -101,6 +101,25 @@ class PoetryTranslationContext extends RawDrupalContext {
   }
 
   /**
+   * Asserts that a given language checkbox is checked.
+   *
+   * @param string $language
+   *   The languages.
+   *
+   * @Then the :language language checkbox in the language list is checked.
+   */
+  public function languageCheckboxIsChecked(string $language): void {
+    $languages = $this->getLanguagesFromNames($language);
+    if (!$languages) {
+      throw new \Exception('The specified languages cannot be found');
+    }
+
+    $langcodes = array_keys($languages);
+    $langcode = reset($langcodes);
+    $this->getSession()->getPage()->hasCheckedField("languages[$langcode]");
+  }
+
+  /**
    * Checks that the Poetry jobs for a given node got created for the languages.
    *
    * @param string $title

--- a/tests/features/poetry_translations.feature
+++ b/tests/features/poetry_translations.feature
@@ -37,7 +37,7 @@ Feature: Poetry translations
     And I should see "Submitted to Poetry" in the "German" row
     And I should see "None" in the "Danish" row
     And I should not see the button "Request DGT translation for the selected languages"
-    And I should see "No translation requests can be made until the ongoing ones have been completed and received."
+    And I should see "No translation requests can be made until the ongoing ones have been accepted."
     And the Poetry request jobs to translate "My title" should get created for "Bulgarian, German"
 
     # The translation gets accepted in Poetry
@@ -49,7 +49,8 @@ Feature: Poetry translations
     And I should see "Ongoing in Poetry" in the "German" row
     And I should see "None" in the "Danish" row
     And I should not see the button "Request DGT translation for the selected languages"
-    And I should see "No translation requests can be made until the ongoing ones have been completed and received."
+    And I should not see "No translation requests can be made until the ongoing ones have been accepted."
+    And I should see the button "Request a translation update"
 
     # The first translation gets sent from Poetry
     When the Poetry translations of "My title" in "Bulgarian" are received from Poetry
@@ -60,7 +61,7 @@ Feature: Poetry translations
     And I click "Translate"
     # Still one job left to come from Poetry
     And I should not see the button "Request DGT translation for the selected languages"
-    And I should see "No translation requests can be made until the ongoing ones have been completed and received."
+    And I should see the button "Request a translation update"
     And I should see "Ongoing in Poetry" in the "German" row
     And I click "Review translation" in the "Bulgarian" row
     Then I should see "Job item My title"
@@ -79,4 +80,5 @@ Feature: Poetry translations
     And I click "My title"
     And I click "Translate"
     And I should see the button "Request DGT translation for the selected languages"
-    And I should not see "No translation requests can be made until the ongoing ones have been completed and received."
+    And I should not see "No translation requests can be made until the ongoing ones have been accepted."
+    And I should not see the button "Request a translation update"

--- a/tests/features/poetry_translations.feature
+++ b/tests/features/poetry_translations.feature
@@ -4,7 +4,7 @@ Feature: Poetry translations
   As a translator
   I need to be able to translate content using the Poetry service
 
-  @cleanup:tmgmt_job @cleanup:tmgmt_job_item @poetry @run
+  @cleanup:tmgmt_job @cleanup:tmgmt_job_item @poetry
   Scenario: Translate content.
     Given oe_demo_translatable_page content:
       | title    | field_oe_demo_translatable_body |

--- a/tests/features/poetry_translations.feature
+++ b/tests/features/poetry_translations.feature
@@ -4,7 +4,7 @@ Feature: Poetry translations
   As a translator
   I need to be able to translate content using the Poetry service
 
-  @cleanup:tmgmt_job @cleanup:tmgmt_job_item @poetry
+  @cleanup:tmgmt_job @cleanup:tmgmt_job_item @poetry @run
   Scenario: Translate content.
     Given oe_demo_translatable_page content:
       | title    | field_oe_demo_translatable_body |
@@ -37,7 +37,8 @@ Feature: Poetry translations
     And I should see "Submitted to Poetry" in the "German" row
     And I should see "None" in the "Danish" row
     And I should not see the button "Request a DGT translation for the selected languages"
-    And I should see "No translation requests can be made until the ongoing ones have been accepted."
+    And I should not see the button "Request a DGT translation update for the selected languages"
+    And I should see "No translation requests can be made until the ongoing ones have been accepted and/or translated."
     And the Poetry request jobs to translate "My title" should get created for "Bulgarian, German"
 
     # The translation gets accepted in Poetry
@@ -49,7 +50,7 @@ Feature: Poetry translations
     And I should see "Ongoing in Poetry" in the "German" row
     And I should see "None" in the "Danish" row
     And I should not see the button "Request a DGT translation for the selected languages"
-    And I should not see "No translation requests can be made until the ongoing ones have been accepted."
+    And I should not see "No translation requests can be made until the ongoing ones have been accepted and/or translated."
     And I should see the button "Request a DGT translation update for the selected languages"
 
     # The first translation gets sent from Poetry
@@ -80,7 +81,7 @@ Feature: Poetry translations
     And I click "My title"
     And I click "Translate"
     And I should see the button "Request a DGT translation for the selected languages"
-    And I should not see "No translation requests can be made until the ongoing ones have been accepted."
+    And I should not see "No translation requests can be made until the ongoing ones have been accepted and/or translated."
     And I should not see the button "Request a DGT translation update for the selected languages"
 
 

--- a/tests/features/poetry_translations.feature
+++ b/tests/features/poetry_translations.feature
@@ -117,7 +117,7 @@ Feature: Poetry translations
     # Make an update request
     When I select the languages "German" in the language list
     And I press "Request a translation update to all selected languages"
-    Then I should see "Send update request to DG Translation for My title to update in Bulgarian, German"
+    Then I should see "Send update request to DG Translation for My title to update in German, Bulgarian"
     When I fill in "Requested delivery date" with "05/04/2050"
     And I fill in the the "first" "Author" field with "john"
     And I fill in "Secretary" with "john"

--- a/tests/features/poetry_translations.feature
+++ b/tests/features/poetry_translations.feature
@@ -38,7 +38,7 @@ Feature: Poetry translations
     And I should see "None" in the "Danish" row
     And I should not see the button "Request a DGT translation for the selected languages"
     And I should not see the button "Request a DGT translation update for the selected languages"
-    And I should see "No translation requests can be made until the ongoing ones have been accepted and/or translated."
+    And I should see "No translation requests to DGT can be made until the ongoing ones have been accepted and/or translated."
     And the Poetry request jobs to translate "My title" should get created for "Bulgarian, German"
 
     # The translation gets accepted in Poetry
@@ -50,7 +50,7 @@ Feature: Poetry translations
     And I should see "Ongoing in Poetry" in the "German" row
     And I should see "None" in the "Danish" row
     And I should not see the button "Request a DGT translation for the selected languages"
-    And I should not see "No translation requests can be made until the ongoing ones have been accepted and/or translated."
+    And I should not see "No translation requests to DGT can be made until the ongoing ones have been accepted and/or translated."
     And I should see the button "Request a DGT translation update for the selected languages"
 
     # The first translation gets sent from Poetry
@@ -81,7 +81,7 @@ Feature: Poetry translations
     And I click "My title"
     And I click "Translate"
     And I should see the button "Request a DGT translation for the selected languages"
-    And I should not see "No translation requests can be made until the ongoing ones have been accepted and/or translated."
+    And I should not see "No translation requests to DGT can be made until the ongoing ones have been accepted and/or translated."
     And I should not see the button "Request a DGT translation update for the selected languages"
 
 

--- a/tests/features/poetry_translations.feature
+++ b/tests/features/poetry_translations.feature
@@ -50,7 +50,7 @@ Feature: Poetry translations
     And I should see "None" in the "Danish" row
     And I should not see the button "Request DGT translation for the selected languages"
     And I should not see "No translation requests can be made until the ongoing ones have been accepted."
-    And I should see the button "Request a translation update"
+    And I should see the button "Request a translation update to all selected languages"
 
     # The first translation gets sent from Poetry
     When the Poetry translations of "My title" in "Bulgarian" are received from Poetry
@@ -61,7 +61,7 @@ Feature: Poetry translations
     And I click "Translate"
     # Still one job left to come from Poetry
     And I should not see the button "Request DGT translation for the selected languages"
-    And I should see the button "Request a translation update"
+    And I should see the button "Request a translation update to all selected languages"
     And I should see "Ongoing in Poetry" in the "German" row
     And I click "Review translation" in the "Bulgarian" row
     Then I should see "Job item My title"
@@ -81,4 +81,78 @@ Feature: Poetry translations
     And I click "Translate"
     And I should see the button "Request DGT translation for the selected languages"
     And I should not see "No translation requests can be made until the ongoing ones have been accepted."
-    And I should not see the button "Request a translation update"
+    And I should not see the button "Request a translation update to all selected languages"
+
+
+  @cleanup:tmgmt_job @cleanup:tmgmt_job_item @poetry
+  Scenario: Translate content and request an update.
+    Given oe_demo_translatable_page content:
+      | title              | field_oe_demo_translatable_body |
+      | My title to update | My body to update               |
+    And I am logged in as a user with the "oe_translator" role
+    When I visit "the content administration page"
+    And I click "My title to update"
+    And I click "Translate"
+    And I select the languages "Bulgarian" in the language list
+    And I press "Request DGT translation for the selected languages"
+    Then I should see "Send request to DG Translation for My title to update in Bulgarian"
+
+    When I fill in "Requested delivery date" with "05/04/2050"
+    And I fill in the the "first" "Author" field with "john"
+    And I fill in "Secretary" with "john"
+    And I fill in "Contact" with "john"
+    And I fill in the the "first" "Responsible" field with "john"
+    And I fill in the the "second" "Responsible" field with "john"
+    And I fill in the the "second" "Author" field with "john"
+    And I fill in "Requester" with "john"
+    And I press "Send request"
+    Then I should see "The request has been sent to DGT."
+    And I should see "Submitted to Poetry" in the "Bulgarian" row
+
+    # The translation gets accepted in Poetry
+    When the Poetry translation request of "My title to update" in "Bulgarian" gets accepted
+    And I reload the page
+    Then I should see "Ongoing in Poetry" in the "Bulgarian" row
+
+    # Make an update request
+    When I select the languages "German" in the language list
+    And I press "Request a translation update to all selected languages"
+    Then I should see "Send update request to DG Translation for My title to update in Bulgarian, German"
+    When I fill in "Requested delivery date" with "05/04/2050"
+    And I fill in the the "first" "Author" field with "john"
+    And I fill in "Secretary" with "john"
+    And I fill in "Contact" with "john"
+    And I fill in the the "first" "Responsible" field with "john"
+    And I fill in the the "second" "Responsible" field with "john"
+    And I fill in the the "second" "Author" field with "john"
+    And I fill in "Requester" with "john"
+    And I press "Send request"
+    Then I should see "The request has been sent to DGT."
+    And I should see "Submitted to Poetry" in the "Bulgarian" row
+    And I should see "Submitted to Poetry" in the "German" row
+    And I should not see the button "Request a translation update to all selected languages"
+
+    # The translations get accepted in Poetry
+    When the Poetry translation request of "My title to update" in "Bulgarian, German" gets accepted
+    And I reload the page
+    Then I should see "Ongoing in Poetry" in the "Bulgarian" row
+    And I should see "Ongoing in Poetry" in the "German" row
+    And I should see the button "Request a translation update to all selected languages"
+
+    # Translation are sent from Poetry
+    When the Poetry translations of "My title to update" in "Bulgarian, German" are received from Poetry
+    And I reload the page
+    And I click "Review translation" in the "German" row
+    When I press "Accept translation"
+    Then I should see "The translation for My title to update has been accepted as My title to update - de"
+    And I click "Review translation" in the "Bulgarian" row
+    When I press "Accept translation"
+    Then I should see "The translation for My title to update has been accepted as My title to update - bg"
+
+    # Go to the translated pages
+    When I click "My title to update - bg"
+    Then I should see "My title to update - bg"
+    And I should see "My body to update - bg"
+    When I click "Deutsch"
+    Then I should see "My title to update - de"
+    And I should see "My body to update - de"

--- a/tests/features/poetry_translations.feature
+++ b/tests/features/poetry_translations.feature
@@ -117,7 +117,7 @@ Feature: Poetry translations
     # Make an update request
     When I select the languages "German" in the language list
     And I press "Request a DGT translation update for the selected languages"
-    Then I should see "Send update request to DG Translation for My title to update in Bulgarian, German"
+    Then I should see "Send update request to DG Translation for My title to update in German, Bulgarian"
     When I fill in "Requested delivery date" with "05/04/2050"
     And I fill in the the "first" "Author" field with "john"
     And I fill in "Secretary" with "john"

--- a/tests/features/poetry_translations.feature
+++ b/tests/features/poetry_translations.feature
@@ -17,7 +17,7 @@ Feature: Poetry translations
     # Request the translation for two languages
     When I click "Translate"
     And I select the languages "Bulgarian, German" in the language list
-    And I press "Request DGT translation for the selected languages"
+    And I press "Request a DGT translation for the selected languages"
     Then I should see "Send request to DG Translation for My title in Bulgarian, German"
 
     When I fill in the the "first" "Author" field with "john"
@@ -36,7 +36,7 @@ Feature: Poetry translations
     And I should see "Submitted to Poetry" in the "Bulgarian" row
     And I should see "Submitted to Poetry" in the "German" row
     And I should see "None" in the "Danish" row
-    And I should not see the button "Request DGT translation for the selected languages"
+    And I should not see the button "Request a DGT translation for the selected languages"
     And I should see "No translation requests can be made until the ongoing ones have been accepted."
     And the Poetry request jobs to translate "My title" should get created for "Bulgarian, German"
 
@@ -48,9 +48,9 @@ Feature: Poetry translations
     And I should see "Ongoing in Poetry" in the "Bulgarian" row
     And I should see "Ongoing in Poetry" in the "German" row
     And I should see "None" in the "Danish" row
-    And I should not see the button "Request DGT translation for the selected languages"
+    And I should not see the button "Request a DGT translation for the selected languages"
     And I should not see "No translation requests can be made until the ongoing ones have been accepted."
-    And I should see the button "Request a translation update to all selected languages"
+    And I should see the button "Request a DGT translation update for the selected languages"
 
     # The first translation gets sent from Poetry
     When the Poetry translations of "My title" in "Bulgarian" are received from Poetry
@@ -60,8 +60,8 @@ Feature: Poetry translations
     And I click "My title"
     And I click "Translate"
     # Still one job left to come from Poetry
-    And I should not see the button "Request DGT translation for the selected languages"
-    And I should see the button "Request a translation update to all selected languages"
+    And I should not see the button "Request a DGT translation for the selected languages"
+    And I should see the button "Request a DGT translation update for the selected languages"
     And I should see "Ongoing in Poetry" in the "German" row
     And I click "Review translation" in the "Bulgarian" row
     Then I should see "Job item My title"
@@ -79,9 +79,9 @@ Feature: Poetry translations
     And I visit "the content administration page"
     And I click "My title"
     And I click "Translate"
-    And I should see the button "Request DGT translation for the selected languages"
+    And I should see the button "Request a DGT translation for the selected languages"
     And I should not see "No translation requests can be made until the ongoing ones have been accepted."
-    And I should not see the button "Request a translation update to all selected languages"
+    And I should not see the button "Request a DGT translation update for the selected languages"
 
 
   @cleanup:tmgmt_job @cleanup:tmgmt_job_item @poetry
@@ -94,7 +94,7 @@ Feature: Poetry translations
     And I click "My title to update"
     And I click "Translate"
     And I select the languages "Bulgarian" in the language list
-    And I press "Request DGT translation for the selected languages"
+    And I press "Request a DGT translation for the selected languages"
     Then I should see "Send request to DG Translation for My title to update in Bulgarian"
 
     When I fill in "Requested delivery date" with "05/04/2050"
@@ -116,8 +116,8 @@ Feature: Poetry translations
 
     # Make an update request
     When I select the languages "German" in the language list
-    And I press "Request a translation update to all selected languages"
-    Then I should see "Send update request to DG Translation for My title to update in German, Bulgarian"
+    And I press "Request a DGT translation update for the selected languages"
+    Then I should see "Send update request to DG Translation for My title to update in Bulgarian, German"
     When I fill in "Requested delivery date" with "05/04/2050"
     And I fill in the the "first" "Author" field with "john"
     And I fill in "Secretary" with "john"
@@ -130,14 +130,14 @@ Feature: Poetry translations
     Then I should see "The request has been sent to DGT."
     And I should see "Submitted to Poetry" in the "Bulgarian" row
     And I should see "Submitted to Poetry" in the "German" row
-    And I should not see the button "Request a translation update to all selected languages"
+    And I should not see the button "Request a DGT translation update for the selected languages"
 
     # The translations get accepted in Poetry
     When the Poetry translation request of "My title to update" in "Bulgarian, German" gets accepted
     And I reload the page
     Then I should see "Ongoing in Poetry" in the "Bulgarian" row
     And I should see "Ongoing in Poetry" in the "German" row
-    And I should see the button "Request a translation update to all selected languages"
+    And I should see the button "Request a DGT translation update for the selected languages"
 
     # Translation are sent from Poetry
     When the Poetry translations of "My title to update" in "Bulgarian, German" are received from Poetry


### PR DESCRIPTION
## OPENEUROPA-2252

### Description

Allow to request translation updates

### Change log

- Added: Route `oe_translation_poetry.job_queue_checkout_update`
- Added: Form `UpdateTranslationRequestForm`
- Changed: Route `oe_translation_poetry.job_queue_checkout` to `oe_translation_poetry.job_queue_checkout_new`
- Changed: `PoetryNotificationTest::prepareRequestedJobs` to `PoetryTranslationTestBase::createNodeWithRequestedJobs`, doing the same but returning the created node.
