### PR TITLE
OPENEUROPA-2697 - Abort also job items when requests are canceled.

### DIFF
--- a/modules/oe_translation_poetry/src/EventSubscriber/PoetryNotificationSubscriber.php
+++ b/modules/oe_translation_poetry/src/EventSubscriber/PoetryNotificationSubscriber.php
@@ -296,9 +296,13 @@ class PoetryNotificationSubscriber implements EventSubscriberInterface {
    *   The message variables.
    */
   protected function rejectJob(JobInterface $job, string $message = '', array $variables = []): void {
+    if ($job->isAborted()) {
+      return;
+    }
+
     $job->set('poetry_state', NULL);
     $job->set('poetry_request_date_updated', NULL);
-    $this->changeJobState($job, Job::STATE_REJECTED, 'state', $message, $variables);
+    $job->aborted($message, $variables, 'status');
   }
 
   /**

--- a/modules/oe_translation_poetry/tests/Functional/PoetryNotificationTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryNotificationTest.php
@@ -57,11 +57,8 @@ class PoetryNotificationTest extends PoetryTranslationTestBase {
         $this->assertEqual($job->getState(), Job::STATE_ABORTED);
         $this->assertCount(1, $job->getMessages());
 
-        $jobItemStorage = $this->entityTypeManager->getStorage('tmgmt_job_item');
         $job_item = current($job->getItems());
-        /** @var \Drupal\tmgmt\JobItemInterface[] $jobItem */
-        $jobItem = $jobItemStorage->load($job_item->id());
-        $this->assertEqual($jobItem->get('state')->value, JobItemInterface::STATE_ABORTED);
+        $this->assertEqual($job_item->get('state')->value, JobItemInterface::STATE_ABORTED);
         continue;
       }
 

--- a/modules/oe_translation_poetry/tests/Functional/PoetryNotificationTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryNotificationTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\oe_translation_poetry\Functional;
 
 use Drupal\oe_translation_poetry\Plugin\tmgmt\Translator\PoetryTranslator;
 use Drupal\tmgmt\Entity\Job;
+use Drupal\tmgmt\JobItemInterface;
 
 /**
  * Tests the Poetry notifications.
@@ -55,6 +56,12 @@ class PoetryNotificationTest extends PoetryTranslationTestBase {
         $this->assertTrue($job->get('poetry_request_date_updated')->isEmpty());
         $this->assertEqual($job->getState(), Job::STATE_REJECTED);
         $this->assertCount(1, $job->getMessages());
+
+        $jobItemStorage = $this->entityTypeManager->getStorage('tmgmt_job_item');
+        $job_item = current($job->getItems());
+        /** @var \Drupal\tmgmt\JobItemInterface[] $jobItem */
+        $jobItem = $jobItemStorage->load($job_item->id());
+        $this->assertEqual($jobItem->get('state')->value, JobItemInterface::STATE_ABORTED);
         continue;
       }
 

--- a/modules/oe_translation_poetry/tests/Functional/PoetryNotificationTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryNotificationTest.php
@@ -54,7 +54,7 @@ class PoetryNotificationTest extends PoetryTranslationTestBase {
         // Italian was refused.
         $this->assertTrue($job->get('poetry_state')->isEmpty());
         $this->assertTrue($job->get('poetry_request_date_updated')->isEmpty());
-        $this->assertEqual($job->getState(), Job::STATE_REJECTED);
+        $this->assertEqual($job->getState(), Job::STATE_ABORTED);
         $this->assertCount(1, $job->getMessages());
 
         $jobItemStorage = $this->entityTypeManager->getStorage('tmgmt_job_item');
@@ -97,7 +97,7 @@ class PoetryNotificationTest extends PoetryTranslationTestBase {
       // The others were cancelled.
       $this->assertTrue($job->get('poetry_state')->isEmpty());
       $this->assertTrue($job->get('poetry_request_date_updated')->isEmpty());
-      $this->assertEqual($job->getState(), Job::STATE_REJECTED);
+      $this->assertEqual($job->getState(), Job::STATE_ABORTED);
     }
   }
 


### PR DESCRIPTION
## OPENEUROPA-2697

### Description

Use aborted method when a request is cancelled by DGT. This will ensure job items are also aborted.
