### PR TITLE
OPENEUROPA-2795: Test we can receive translation updates while a job is active

### DIFF
--- a/modules/oe_translation_poetry/modules/oe_translation_poetry_mock/src/Controller/PoetryMockController.php
+++ b/modules/oe_translation_poetry/modules/oe_translation_poetry_mock/src/Controller/PoetryMockController.php
@@ -203,8 +203,10 @@ class PoetryMockController extends ControllerBase {
     $item = reset($items);
     $data = \Drupal::service('tmgmt.data')->filterTranslatable($item->getData());
     foreach ($data as $field => &$info) {
+      // Check whether this is a new translation or not by checking for a
+      // stored translation for the field.
       if (isset($info['#translation'])) {
-        $info['#text'] = $info['#translation']['#text'] . ' UPDATE';
+        $info['#text'] = $info['#translation']['#text'] . ' OVERRIDDEN';
       }
       else {
         $info['#text'] .= ' - ' . $tmgmt_job->getTargetLangcode();

--- a/modules/oe_translation_poetry/modules/oe_translation_poetry_mock/src/Controller/PoetryMockController.php
+++ b/modules/oe_translation_poetry/modules/oe_translation_poetry_mock/src/Controller/PoetryMockController.php
@@ -203,7 +203,13 @@ class PoetryMockController extends ControllerBase {
     $item = reset($items);
     $data = \Drupal::service('tmgmt.data')->filterTranslatable($item->getData());
     foreach ($data as $field => &$info) {
-      $info['#text'] .= ' - ' . $tmgmt_job->getTargetLangcode();
+      if (isset($info['#translation'])) {
+        $info['#text'] = $info['#translation']['#text'] . ' UPDATE';
+      }
+      else {
+        $info['#text'] .= ' - ' . $tmgmt_job->getTargetLangcode();
+
+      }
     }
 
     // We need to render this in a new context to prevent cache leaks.

--- a/modules/oe_translation_poetry/modules/oe_translation_poetry_mock/src/EventSubscriber/ContentTranslationOverviewAlterSubscriber.php
+++ b/modules/oe_translation_poetry/modules/oe_translation_poetry_mock/src/EventSubscriber/ContentTranslationOverviewAlterSubscriber.php
@@ -81,6 +81,7 @@ class ContentTranslationOverviewAlterSubscriber implements EventSubscriberInterf
     $destination = $entity->toUrl('drupal:content-translation-overview');
     $submitted_jobs = $this->getJobsByState($entity, Job::STATE_ACTIVE);
     $ongoing_jobs = $this->getJobsByState($entity, Job::STATE_ACTIVE, 'ongoing');
+    $translated_jobs = $this->getJobsByState($entity, Job::STATE_ACTIVE, 'translated');
 
     $languages = $this->languageManager->getLanguages();
     foreach ($languages as $langcode => $language) {
@@ -130,6 +131,16 @@ class ContentTranslationOverviewAlterSubscriber implements EventSubscriberInterf
           'url' => Url::fromRoute('oe_translation_poetry_mock.send_status_notification', [
             'tmgmt_job' => $ongoing_jobs[$language->getId()]->tjid,
             'status' => 'CNL',
+          ],
+            $url_options
+          ),
+        ];
+      }
+      if (isset($translated_jobs[$language->getId()])) {
+        $links['update_translation'] = [
+          'title' => $this->t('Update translation (mock)'),
+          'url' => Url::fromRoute('oe_translation_poetry_mock.send_translation_notification', [
+            'tmgmt_job' => $translated_jobs[$language->getId()]->tjid,
           ],
             $url_options
           ),

--- a/modules/oe_translation_poetry/modules/oe_translation_poetry_mock/src/EventSubscriber/ContentTranslationOverviewAlterSubscriber.php
+++ b/modules/oe_translation_poetry/modules/oe_translation_poetry_mock/src/EventSubscriber/ContentTranslationOverviewAlterSubscriber.php
@@ -115,32 +115,27 @@ class ContentTranslationOverviewAlterSubscriber implements EventSubscriberInterf
           ),
         ];
       }
-
-      if (isset($ongoing_jobs[$language->getId()])) {
+      // We can send a translation if a job is ongoing or if the translation
+      // hasn't been accepted yet.
+      if (isset($ongoing_jobs[$language->getId()]) || isset($translated_jobs[$language->getId()])) {
+        $tjid = isset($ongoing_jobs[$language->getId()]) ? $ongoing_jobs[$language->getId()]->tjid : $translated_jobs[$language->getId()]->tjid;
         $links['translate_job'] = [
           'title' => $this->t('Translate job (mock)'),
-          'url' => Url::fromRoute('oe_translation_poetry_mock.send_translation_notification', [
-            'tmgmt_job' => $ongoing_jobs[$language->getId()]->tjid,
-          ],
+          'url' => Url::fromRoute(
+            'oe_translation_poetry_mock.send_translation_notification',
+            [
+              'tmgmt_job' => $tjid,
+            ],
             $url_options
           ),
         ];
-
+      }
+      if (isset($ongoing_jobs[$language->getId()])) {
         $links['cancel_job'] = [
           'title' => $this->t('Cancel job (mock)'),
           'url' => Url::fromRoute('oe_translation_poetry_mock.send_status_notification', [
             'tmgmt_job' => $ongoing_jobs[$language->getId()]->tjid,
             'status' => 'CNL',
-          ],
-            $url_options
-          ),
-        ];
-      }
-      if (isset($translated_jobs[$language->getId()])) {
-        $links['update_translation'] = [
-          'title' => $this->t('Update translation (mock)'),
-          'url' => Url::fromRoute('oe_translation_poetry_mock.send_translation_notification', [
-            'tmgmt_job' => $translated_jobs[$language->getId()]->tjid,
           ],
             $url_options
           ),

--- a/modules/oe_translation_poetry/tests/Functional/PoetryConfigurationTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryConfigurationTest.php
@@ -108,7 +108,7 @@ class PoetryConfigurationTest extends PoetryTranslationTestBase {
     $request = $message->request;
 
     // Check identifier with the custom code.
-    $this->assertEqual((string) $request->attributes()['id'], $form_values['settings[identifier_code]'] . '/' . date('Y') . '/NEXT_EUROPA_COUNTER/0/0/TRA');
+    $this->assertEquals((string) $request->attributes()['id'], $form_values['settings[identifier_code]'] . '/' . date('Y') . '/NEXT_EUROPA_COUNTER/0/0/TRA');
 
     // Check the title.
     $title = (string) new FormattableMarkup('@prefix: @site_id - @title', [

--- a/modules/oe_translation_poetry/tests/Functional/PoetryMockTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryMockTest.php
@@ -47,7 +47,7 @@ class PoetryMockTest extends BrowserTestBase {
     $settings = $poetry->getSettings();
 
     foreach ($expected_settings as $name => $setting) {
-      $this->assertEqual($settings[$name], $setting);
+      $this->assertEquals($setting, $settings[$name]);
     }
 
     $settings->set('service.wsdl', PoetryMock::getWsdlUrl());
@@ -87,7 +87,7 @@ class PoetryMockTest extends BrowserTestBase {
     $response = $client->send($message);
     $this->assertInstanceOf(MessageInterface::class, $response);
     $expected = $fixture_generator->responseFromMessage($message);
-    $this->assertEqual($expected, $response->getRaw());
+    $this->assertEquals($expected, $response->getRaw());
 
     // Check the request and response have been logged.
     $result = $this->container->get('database')
@@ -100,7 +100,7 @@ class PoetryMockTest extends BrowserTestBase {
     $this->assertCount(1, $result);
     $logged_message = trim(unserialize(reset($result))['@message'], "'");
     $logged_message_id = (string) simplexml_load_string($logged_message)->request->attributes()['id'];
-    $this->assertEqual($logged_message_id, 'WEB/' . date('Y') . '/40012/0/33/TRA');
+    $this->assertEquals('WEB/' . date('Y') . '/40012/0/33/TRA', $logged_message_id);
   }
 
   /**
@@ -129,7 +129,7 @@ class PoetryMockTest extends BrowserTestBase {
       $response = $client->send($message);
     }
     catch (ParsingException $exception) {
-      $this->assertEqual($exception->getMessage(), "XML message could not be parsed: ERROR: Authentication failed.");
+      $this->assertEquals('XML message could not be parsed: ERROR: Authentication failed.', $exception->getMessage());
     }
 
     // Use the correct credentials to access the service.
@@ -144,7 +144,7 @@ class PoetryMockTest extends BrowserTestBase {
     $client = $poetry->getClient();
     $response = $client->send($message);
     $this->assertInstanceOf(Status::class, $response);
-    $this->assertEqual($response->getRequestStatus()->getMessage(), 'Error in xmlActions:newRequest: A request with the same references if already in preparation another product exists for this reference.');
+    $this->assertEquals('Error in xmlActions:newRequest: A request with the same references if already in preparation another product exists for this reference.', $response->getRequestStatus()->getMessage());
 
     $this->container->set('oe_translation_poetry.client.default', NULL);
     /** @var \Drupal\oe_translation_poetry\Poetry $poetry */
@@ -160,7 +160,7 @@ class PoetryMockTest extends BrowserTestBase {
     $client = $poetry->getClient();
     $response = $client->send($message);
     $this->assertInstanceOf(Status::class, $response);
-    $this->assertEqual($response->getRequestStatus()->getMessage(), 'Error in xmlActions:newRequest: Application general error : Element DEMANDEID.NUMERO.XMLTEXT is undefined in REQ_ROOT.,');
+    $this->assertEquals('Error in xmlActions:newRequest: Application general error : Element DEMANDEID.NUMERO.XMLTEXT is undefined in REQ_ROOT.,', $response->getRequestStatus()->getMessage());
   }
 
 }

--- a/modules/oe_translation_poetry/tests/Functional/PoetryRequestIdFieldWidgetTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryRequestIdFieldWidgetTest.php
@@ -75,14 +75,14 @@ class PoetryRequestIdFieldWidgetTest extends TranslationTestBase {
 
     /** @var \Drupal\node\NodeInterface $node */
     $node = $this->entityTypeManager->getStorage('node')->load(1);
-    $this->assertEqual([
+    $this->assertEquals($node->get('poetry_request_id')->first()->getValue(), [
       'code' => 'WEB',
       'year' => '2019',
       'number' => 102,
       'version' => 1,
       'part' => 1,
       'product' => 'TRA',
-    ], $node->get('poetry_request_id')->first()->getValue());
+    ]);
   }
 
 }

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
@@ -43,8 +43,8 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
     $this->assertCount(2, $jobs);
     foreach ($jobs as $lang => $job) {
       // The jobs should still be unprocessed at this stage.
-      $this->assertEqual($job->getState(), JobInterface::STATE_UNPROCESSED);
-      $this->assertEqual($job->getTargetLangcode(), $lang);
+      $this->assertEquals(JobInterface::STATE_UNPROCESSED, $job->getState());
+      $this->assertEquals($lang, $job->getTargetLangcode());
     }
 
     // Submit the request to Poetry for the two jobs.
@@ -78,8 +78,8 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
     $this->assertCount(2, $jobs);
     foreach ($jobs as $lang => $job) {
       // The jobs should still be unprocessed at this stage.
-      $this->assertEqual($job->getState(), JobInterface::STATE_UNPROCESSED);
-      $this->assertEqual($job->getTargetLangcode(), $lang);
+      $this->assertEquals(JobInterface::STATE_UNPROCESSED, $job->getState());
+      $this->assertEquals($lang, $job->getTargetLangcode());
     }
 
     // Submit the request to Poetry for the two new jobs in the queue.
@@ -122,8 +122,8 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
     $this->assertCount(2, $jobs);
     foreach ($jobs as $lang => $job) {
       // The jobs should still be unprocessed at this stage.
-      $this->assertEqual($job->getState(), JobInterface::STATE_UNPROCESSED);
-      $this->assertEqual($job->getTargetLangcode(), $lang);
+      $this->assertEquals(JobInterface::STATE_UNPROCESSED, $job->getState());
+      $this->assertEquals($lang, $job->getTargetLangcode());
     }
 
     // Submit the request to Poetry for the two jobs.
@@ -176,8 +176,8 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
     $this->assertCount(2, $jobs);
     foreach ($jobs as $lang => $job) {
       // The jobs should still be unprocessed at this stage.
-      $this->assertEqual($job->getState(), JobInterface::STATE_UNPROCESSED);
-      $this->assertEqual($job->getTargetLangcode(), $lang);
+      $this->assertEquals(JobInterface::STATE_UNPROCESSED, $job->getState());
+      $this->assertEquals($lang, $job->getTargetLangcode());
     }
 
     // Submit the request to Poetry for the two jobs.
@@ -300,8 +300,8 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
     foreach ($jobs as $lang => $job) {
       /** @var \Drupal\tmgmt\JobInterface $job */
       $job = $this->jobStorage->load($job->id());
-      $this->assertEqual($job->getState(), JobInterface::STATE_ACTIVE);
-      $this->assertEqual($job->get('poetry_request_id')->first()->getValue(), $values);
+      $this->assertEquals(JobInterface::STATE_ACTIVE, $job->getState());
+      $this->assertEquals($values, $job->get('poetry_request_id')->first()->getValue());
     }
   }
 

--- a/modules/oe_translation_poetry/tests/Kernel/PoetryRequestIdFieldTest.php
+++ b/modules/oe_translation_poetry/tests/Kernel/PoetryRequestIdFieldTest.php
@@ -72,7 +72,7 @@ class PoetryRequestIdFieldTest extends TranslationKernelTestBase {
     /** @var \Drupal\node\NodeInterface $node */
     $node = $node_storage->load($node->id());
 
-    $this->assertEqual($poetry_id, $node->get('poetry_request_id')->first()->getValue());
+    $this->assertEquals($poetry_id, $node->get('poetry_request_id')->first()->getValue());
 
     $builder = $this->container->get('entity_type.manager')->getViewBuilder('node');
     $build = $builder->viewField($node->get('poetry_request_id'));

--- a/modules/oe_translation_poetry/tests/Kernel/PoetryRequestIdentifierTest.php
+++ b/modules/oe_translation_poetry/tests/Kernel/PoetryRequestIdentifierTest.php
@@ -69,14 +69,14 @@ class PoetryRequestIdentifierTest extends TranslationKernelTestBase {
     // Test initial identifier.
     $identifier = $poetry->getIdentifierForContent($node_one);
     // The identifier needs to contain a sequence as it's the first request.
-    $this->assertEqual($identifier->getSequence(), 'SEQUENCE');
+    $this->assertEquals('SEQUENCE', $identifier->getSequence());
     // There should be no number as it's the first request.
-    $this->assertEqual($identifier->getNumber(), '');
-    $this->assertEqual($identifier->getCode(), 'WEB');
-    $this->assertEqual($identifier->getPart(), 0);
-    $this->assertEqual($identifier->getVersion(), 0);
+    $this->assertEquals('', $identifier->getNumber());
+    $this->assertEquals('WEB', $identifier->getCode());
+    $this->assertEquals(0, $identifier->getPart());
+    $this->assertEquals(0, $identifier->getVersion());
     // The date is generated dynamically.
-    $this->assertEqual($identifier->getYear(), date('Y'));
+    $this->assertEquals(date('Y'), $identifier->getYear());
 
     // Simulate a previous translation for node 1.
     $job = tmgmt_job_create('en', 'de', 0, [
@@ -100,22 +100,22 @@ class PoetryRequestIdentifierTest extends TranslationKernelTestBase {
     // Test identifier for node having already a job and assert that its values
     // are the same as the previous job with just the version incremented.
     $identifier = $poetry->getIdentifierForContent($node_one);
-    $this->assertEqual($identifier->getSequence(), '');
-    $this->assertEqual($identifier->getNumber(), '11111');
-    $this->assertEqual($identifier->getPart(), '0');
-    $this->assertEqual($identifier->getVersion(), '1');
-    $this->assertEqual($identifier->getYear(), '2018');
+    $this->assertEquals('', $identifier->getSequence());
+    $this->assertEquals('11111', $identifier->getNumber());
+    $this->assertEquals('0', $identifier->getPart());
+    $this->assertEquals('1', $identifier->getVersion());
+    $this->assertEquals('2018', $identifier->getYear());
 
     // Test identifier for another node.
     $identifier = $poetry->getIdentifierForContent($node_two);
-    $this->assertEqual($identifier->getSequence(), '');
+    $this->assertEquals('', $identifier->getSequence());
     // The number is set globally from the previous request.
-    $this->assertEqual($identifier->getNumber(), '11111');
+    $this->assertEquals('11111', $identifier->getNumber());
     // The part is increased by one from the previous request.
-    $this->assertEqual($identifier->getPart(), '1');
-    $this->assertEqual($identifier->getVersion(), '0');
+    $this->assertEquals('1', $identifier->getPart());
+    $this->assertEquals('0', $identifier->getVersion());
     // The date is generated dynamically.
-    $this->assertEqual($identifier->getYear(), date('Y'));
+    $this->assertEquals(date('Y'), $identifier->getYear());
 
     // Delete the jobs from the system to mimic a data loss and ensure a new
     // number is requested in this case to start over.
@@ -127,11 +127,11 @@ class PoetryRequestIdentifierTest extends TranslationKernelTestBase {
     // We should not be sending a number to Poetry, even though we have it
     // already because the jobs were lost. So the sequence should be sent.
     $identifier = $poetry->getIdentifierForContent($node_one);
-    $this->assertEqual($identifier->getSequence(), 'SEQUENCE');
-    $this->assertEqual($identifier->getNumber(), '');
-    $this->assertEqual($identifier->getPart(), '0');
-    $this->assertEqual($identifier->getVersion(), '0');
-    $this->assertEqual($identifier->getYear(), date('Y'));
+    $this->assertEquals('SEQUENCE', $identifier->getSequence());
+    $this->assertEquals('', $identifier->getNumber());
+    $this->assertEquals('0', $identifier->getPart());
+    $this->assertEquals('0', $identifier->getVersion());
+    $this->assertEquals(date('Y'), $identifier->getYear());
 
     // Create another finished translation for the first node but increase the
     // part to 99 to mimic the end of the number. In this case we again need
@@ -153,11 +153,11 @@ class PoetryRequestIdentifierTest extends TranslationKernelTestBase {
     $identifier = $poetry->getIdentifierForContent($node_two);
     // The identifier needs to again contain the sequence to request a new
     // number as 99 was reached.
-    $this->assertEqual($identifier->getSequence(), 'SEQUENCE');
-    $this->assertEqual($identifier->getNumber(), '');
-    $this->assertEqual($identifier->getPart(), '0');
-    $this->assertEqual($identifier->getVersion(), '0');
-    $this->assertEqual($identifier->getYear(), date('Y'));
+    $this->assertEquals('SEQUENCE', $identifier->getSequence());
+    $this->assertEquals('', $identifier->getNumber());
+    $this->assertEquals('0', $identifier->getPart());
+    $this->assertEquals('0', $identifier->getVersion());
+    $this->assertEquals(date('Y'), $identifier->getYear());
   }
 
 }

--- a/modules/oe_translation_poetry/tests/Traits/PoetryTestTrait.php
+++ b/modules/oe_translation_poetry/tests/Traits/PoetryTestTrait.php
@@ -66,12 +66,12 @@ trait PoetryTestTrait {
    *
    * @param \Drupal\tmgmt\JobInterface[] $jobs
    *   The jobs.
-   * @param string $suffix
+   * @param string|null $suffix
    *   A string to append to the translation..
    *
    * @throws \Drupal\Core\TypedData\Exception\MissingDataException
    */
-  protected function notifyWithDummyTranslations(array $jobs, string $suffix = ''): void {
+  protected function notifyWithDummyTranslations(array $jobs, string $suffix = NULL): void {
     // Prepare the identifier.
     $identifier = new Identifier();
     $main_job = current($jobs);

--- a/modules/oe_translation_poetry/tests/Traits/PoetryTestTrait.php
+++ b/modules/oe_translation_poetry/tests/Traits/PoetryTestTrait.php
@@ -66,10 +66,12 @@ trait PoetryTestTrait {
    *
    * @param \Drupal\tmgmt\JobInterface[] $jobs
    *   The jobs.
+   * @param string $suffix
+   *   A string to append to the translation..
    *
    * @throws \Drupal\Core\TypedData\Exception\MissingDataException
    */
-  protected function notifyWithDummyTranslations(array $jobs): void {
+  protected function notifyWithDummyTranslations(array $jobs, string $suffix = ''): void {
     // Prepare the identifier.
     $identifier = new Identifier();
     $main_job = current($jobs);
@@ -86,6 +88,9 @@ trait PoetryTestTrait {
       $data = $this->getContainer()->get('tmgmt.data')->filterTranslatable($item->getData());
       foreach ($data as $field => &$info) {
         $info['#text'] .= ' - ' . $job->getTargetLangcode();
+        if ($suffix) {
+          $info['#text'] .= ' ' . $suffix;
+        }
       }
 
       $translation_notification = $this->getContainer()->get('oe_translation_poetry_mock.fixture_generator')->translationNotification($identifier, $job->getTargetLangcode(), $data, (int) $main_item->id(), (int) $main_job->id());


### PR DESCRIPTION
## OPENEUROPA-2795

### Description

We need to be able to receive and update translations while a job is active. 
Add tests and the possibility to manually test this functionality.
### Change log

- Added: Tests for updating translations and new option to mock it.
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

