### PR TITLE
OPENEUROPA-0000: Checkbox assertion update after symfony dom crawler update

### DIFF
--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationUpdateRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationUpdateRequestTest.php
@@ -59,8 +59,10 @@ class PoetryTranslationUpdateRequestTest extends PoetryTranslationTestBase {
     // At the moment, since there is an ongoing request to Poetry (at least one
     // ongoing job), we can make an update request which needs to include all
     // ongoing jobs and any extra we may want.
-    $this->assertSession()->checkboxChecked('edit-languages-bg');
-    $this->assertSession()->checkboxChecked('edit-languages-cs');
+    // Use the attribute to check of the field is checked as it will be disabled
+    // and removed from the field list.
+    $this->assertTrue($this->getSession()->getPage()->findField('edit-languages-bg')->getAttribute('checked') === 'checked');
+    $this->assertTrue($this->getSession()->getPage()->findField('edit-languages-cs')->getAttribute('checked') === 'checked');
     $this->assertSession()->fieldDisabled('edit-languages-bg');
     $this->assertSession()->fieldDisabled('edit-languages-cs');
 

--- a/tests/Behat/PoetryTranslationContext.php
+++ b/tests/Behat/PoetryTranslationContext.php
@@ -8,6 +8,7 @@ use Behat\Behat\Hook\Scope\AfterFeatureScope;
 use Behat\Behat\Hook\Scope\BeforeFeatureScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Element\NodeElement;
 use Drupal\Core\Database\Query\SelectInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
@@ -108,17 +109,27 @@ class PoetryTranslationContext extends RawDrupalContext {
    * @param string $language
    *   The languages.
    *
-   * @Then the :language language checkbox in the language list is checked.
+   * @Then the :language language checkbox in the language list is checked
    */
   public function languageCheckboxIsChecked(string $language): void {
     $languages = $this->getLanguagesFromNames($language);
     if (!$languages) {
-      throw new \Exception('The specified languages cannot be found');
+      throw new \Exception('The specified language cannot be found');
     }
 
     $langcodes = array_keys($languages);
     $langcode = reset($langcodes);
-    $this->getSession()->getPage()->hasCheckedField("languages[$langcode]");
+    $checkbox = $this->getSession()->getPage()->findField("languages[$langcode]");
+    if (!$checkbox instanceof NodeElement) {
+      throw new \Exception('The specified language cannot be found');
+    }
+
+    // We use the "checked" attribute because the checkbox may be disabled and
+    // the dom crawler does not include it in the available form elements.
+    $checked = $checkbox->getAttribute('checked') === 'checked';
+    if (!$checked) {
+      throw new \Exception('The specified language checkbox is not checked and it should have been.');
+    }
   }
 
   /**

--- a/tests/features/poetry_translations.feature
+++ b/tests/features/poetry_translations.feature
@@ -118,6 +118,7 @@ Feature: Poetry translations
     When the Poetry translation request of "My title to update" in "Bulgarian" gets accepted
     And I reload the page
     Then I should see "Ongoing in Poetry" in the "Bulgarian" row
+    And the "Bulgarian" language checkbox in the language list is checked
 
     # Make an update request
     When I select the languages "German" in the language list


### PR DESCRIPTION
The symfony DOM crawler updated and removed the disabled fields from the available form elements it can make assertions on. So we need to update a step that checks for a checkbox that might be disabled.