### PR TITLE
OPENEUROPA-2726: Reverting the job item abort capability.

### DIFF
--- a/modules/oe_translation_poetry/oe_translation_poetry.module
+++ b/modules/oe_translation_poetry/oe_translation_poetry.module
@@ -167,6 +167,11 @@ function oe_translation_poetry_tmgmt_job_item_access(EntityInterface $entity, $o
     return AccessResult::neutral();
   }
 
+  if ($operation === 'abort') {
+    // We don't want to abort jobs items.
+    return AccessResult::forbidden();
+  }
+
   if ($operation !== 'update') {
     return AccessResult::neutral();
   }

--- a/modules/oe_translation_poetry/src/Form/JobItemAbortForm.php
+++ b/modules/oe_translation_poetry/src/Form/JobItemAbortForm.php
@@ -19,6 +19,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a form for cancelling a translation job item.
+ *
+ * Currently not used, we should reintroduce once we clarify the impact on
+ * aborting local jobs items.
  */
 class JobItemAbortForm extends OriginalJobItemAbortForm {
 

--- a/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
+++ b/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
@@ -52,8 +52,7 @@ use Symfony\Component\Routing\RouteCollection;
  *   description = @Translation("Allows the users to send translation requests to Poetry."),
  *   ui = "\Drupal\oe_translation_poetry\PoetryTranslatorUI",
  *   default_settings = {},
- *   map_remote_languages = TRUE,
- *   abort_class = "\Drupal\oe_translation_poetry\Form\JobItemAbortForm"
+ *   map_remote_languages = TRUE
  * )
  *
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
@@ -318,12 +317,7 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
     }
 
     if (isset($form['actions']['abort_job_item'])) {
-      $form['actions']['abort_job_item']['#attributes']['class'] = ['button'];
-      $form['actions']['abort_job_item']['#title'] = $this->t('Cancel translation job item');
-    }
-
-    if (isset($form['actions']['preview'])) {
-      $form['actions']['preview']['#weight'] = 100;
+      unset($form['actions']['abort_job_item']);
     }
 
     // Hide the validation checkmarks.

--- a/tests/features/poetry_translations.feature
+++ b/tests/features/poetry_translations.feature
@@ -166,7 +166,7 @@ Feature: Poetry translations
     And I should see "My body to update - de"
 
   @cleanup:tmgmt_job @cleanup:tmgmt_job_item @poetry
-  Scenario: Cancel and abort languages and requests.
+  Scenario: Cancel languages and requests.
     Given oe_demo_translatable_page content:
       | title                 | field_oe_demo_translatable_body |
       | My title to translate | My body to translate            |
@@ -252,22 +252,6 @@ Feature: Poetry translations
     And I should not see "Cancelled in Poetry" in the "Bulgarian" row
     And I should not see "Cancelled in Poetry" in the "Czech" row
     And I should see "Submitted to Poetry" in the "Spanish" row
-
-    # Translation gets accepted in Poetry, sent and we can cancel it locally.
-    When Poetry updates the status for "My title to translate" as "Ongoing" with the following individual statuses
-      | language | status  |
-      | Spanish  | Ongoing |
-    And the Poetry translation of "My title to translate" in "Spanish" is received from Poetry
-    And I reload the page
-    And I click "Review translation"
-    Then I should see "Job item My title to translate"
-    # Cancel the translation item.
-    When I click "Cancel translation job item"
-    Then I should see "Are you sure you want to cancel the translation for My title to translate in Spanish"
-    And I should see "Please be aware that DGT will not be notified and cancelled translations can no longer be accepted or resent from DGT without making a brand new request."
-    When I press "Confirm"
-    Then I should see the success message "The translation has been cancelled."
-    And I should see "None" in the "Spanish" row
 
   @cleanup:tmgmt_job @cleanup:tmgmt_job_item @poetry
   Scenario: Translate content and add languages.


### PR DESCRIPTION
We had to revert this capability because it interferes logically with the ability to add new languages to an existing request and constraints of the Poetry API.