### PR TITLE
OPENEUROPA-2608: Route access fixes for TMGMT-translated entity types

### DIFF
--- a/oe_translation.module
+++ b/oe_translation.module
@@ -200,16 +200,27 @@ function oe_translation_entity_base_field_info_alter(&$fields, EntityTypeInterfa
 }
 
 /**
- * Implements hook_ENTITY_TYPE_access() for the Node entity type.
+ * Implements hook_entity_access().
  */
-function oe_translation_node_access(EntityInterface $entity, $operation, AccountInterface $account) {
+function oe_translation_entity_access(EntityInterface $entity, $operation, AccountInterface $account) {
+  if (!$entity instanceof ContentEntityInterface) {
+    return AccessResult::neutral();
+  }
+
   if (!in_array($operation, ['update'])) {
     // @todo, see if we should allow the deletion of translations.
     return AccessResult::neutral();
   }
 
-  // We do not want node translations to be manually edited.
-  // They need to be controlled from TMGMT.
+  $entity_type = $entity->getEntityTypeId();
+  $handler = \Drupal::entityTypeManager()->getHandler($entity_type, 'oe_translation');
+  $supported_translations = $handler->getSupportedTranslators();
+  if (!$supported_translations) {
+    return AccessResult::neutral();
+  }
+
+  // We do not want translations to be manually edited if they are supported
+  // by our TMGMT translators.
   if (!$entity->isDefaultTranslation()) {
     return AccessResult::forbidden()->addCacheableDependency($entity);
   }

--- a/oe_translation.services.yml
+++ b/oe_translation.services.yml
@@ -22,6 +22,6 @@ services:
       - { name: access_check, applies_to: _access_oe_translation }
   oe_translation.request_subscriber:
     class: Drupal\oe_translation\EventSubscriber\TranslationOverviewRequestSubscriber
-    arguments: ['@current_route_match', '@entity_type.manager']
+    arguments: ['@current_route_match', '@entity_type.manager', '@language_manager']
     tags:
       - { name: event_subscriber }

--- a/tests/Functional/TranslationInterfaceTest.php
+++ b/tests/Functional/TranslationInterfaceTest.php
@@ -13,9 +13,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * Tests that we are allowing Translator plugins to make alterations.
+ * Tests the various translation interfaces.
  */
-class ExtensibilityTest extends TranslationTestBase {
+class TranslationInterfaceTest extends TranslationTestBase {
 
   /**
    * Tests that the plugins can alter pages and forms, and propose routes.

--- a/tests/modules/oe_translation_test/oe_translation_test.module
+++ b/tests/modules/oe_translation_test/oe_translation_test.module
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * The OE Translation Test module.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\oe_translation_test\TranslationHandler;
+
+/**
+ * Implements hook_entity_type_alter().
+ */
+function oe_translation_test_entity_type_alter(array &$entity_types) {
+  /** @var \Drupal\Core\Entity\EntityTypeInterface $entity_type */
+  foreach ($entity_types as $entity_type_id => $entity_type) {
+    if ($entity_type->hasHandlerClass('oe_translation')) {
+      $entity_type->setHandlerClass('oe_translation', TranslationHandler::class);
+    }
+  }
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ */
+function oe_translation_test_module_implements_alter(&$implementations, $hook) {
+  switch ($hook) {
+    case 'entity_type_alter':
+      $group = $implementations['oe_translation_test'];
+      unset($implementations['oe_translation_test']);
+      $implementations['oe_translation_test'] = $group;
+      break;
+  }
+}

--- a/tests/modules/oe_translation_test/src/TranslationHandler.php
+++ b/tests/modules/oe_translation_test/src/TranslationHandler.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_translation_test;
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\oe_translation\OeTranslationHandler;
+use Drupal\tmgmt\TranslatorManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Test translation handler.
+ */
+class TranslationHandler extends OeTranslationHandler {
+
+  /**
+   * The state service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * TranslationHandler constructor.
+   *
+   * @param \Drupal\tmgmt\TranslatorManager $translatorManager
+   *   The translator manager.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state service.
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   The entity type.
+   */
+  public function __construct(TranslatorManager $translatorManager, EntityTypeManagerInterface $entityTypeManager, StateInterface $state, EntityTypeInterface $entity_type) {
+    parent::__construct($translatorManager, $entityTypeManager, $entity_type);
+    $this->state = $state;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    return new static(
+      $container->get('plugin.manager.tmgmt.translator'),
+      $container->get('entity_type.manager'),
+      $container->get('state'),
+      $entity_type
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSupportedTranslators(): array {
+    $supported = parent::getSupportedTranslators();
+
+    $enabled_entity_types = $this->state->get('oe_translation_test_enabled_translators', []);
+    if (in_array($this->entityType->id(), $enabled_entity_types)) {
+      // Enable one of the translators for the entity type.
+      $supported[] = 'permission';
+    }
+
+    return $supported;
+  }
+
+}


### PR DESCRIPTION
* Ensures that the translation overview page of TMGMT-translatable entity types are only accessible in the default language of the entity.
* Ensures that entities which are exposed to the TMGMT translators are not editable in a language other than its default (source).