### PR TITLE
OPENEUROPA-3017: Moving the Poetry endpoint to an environment variable.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ services:
     environment: &web-environment
       - DOCUMENT_ROOT=/test/oe_translation
       - POETRY_IDENTIFIER_SEQUENCE=NEXT_EUROPA_COUNTER
+      - POETRY_SERVICE_ENDPOINT=http://web:8080/build/poetry-mock/wsdl
       - POETRY_SERVICE_USERNAME=admin
       - POETRY_SERVICE_PASSWORD=admin
       - POETRY_NOTIFICATION_USERNAME=admin

--- a/composer.json
+++ b/composer.json
@@ -11,22 +11,25 @@
         "drupal/tmgmt": "^1.8"
     },
     "require-dev": {
+        "behat/mink-selenium2-driver": "1.4.x-dev as 1.3.x-dev",
         "composer/installers": "~1.5",
         "drupal-composer/drupal-scaffold": "~2.2",
+        "drupal/address": "^1.8",
+        "drupal/block_field": "~1.0.0-alpha8",
         "drupal/config_devel": "~1.2",
         "drupal/drupal-extension": "~4.0",
+        "drupal/paragraphs": "^1.11",
         "drush/drush": "~9.0@stable",
+        "ec-europa/oe-poetry-client": "dev-master",
         "guzzlehttp/guzzle": "~6.3",
         "openeuropa/behat-transformation-context": "~0.1.2",
         "openeuropa/code-review": "~1.0.0",
-        "openeuropa/oe_multilingual": "dev-master",
         "openeuropa/drupal-core-require-dev": "^8.7",
+        "openeuropa/oe_multilingual": "dev-master",
         "openeuropa/task-runner": "~1.0.0-beta6",
         "phpunit/phpunit": "~6.0",
         "symfony/browser-kit": "~3.0||~4.0",
-        "ec-europa/oe-poetry-client": "dev-master",
-        "behat/mink-selenium2-driver": "1.4.x-dev as 1.3.x-dev",
-        "drupal/block_field": "~1.0.0-alpha8"
+        "drupaltest/behat-traits": "~0.1"
     },
     "_readme": [
         "We explicitly require consolidation/robo to allow lower 'composer update --prefer-lowest' to complete successfully.",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       # For Mac users: sudo ifconfig en0 alias 10.254.254.254 255.255.255.0
       # For Linux users: sudo ip addr add 10.254.254.254/32 dev lo label lo:1
       POETRY_IDENTIFIER_SEQUENCE: "NEXT_EUROPA_COUNTER"
+      POETRY_SERVICE_ENDPOINT: "http://localhost:8080/build/poetry-mock/wsdl"
       POETRY_SERVICE_USERNAME: "admin"
       POETRY_SERVICE_PASSWORD: "admin"
       POETRY_NOTIFICATION_USERNAME: "admin"

--- a/modules/oe_translation_poetry/README.md
+++ b/modules/oe_translation_poetry/README.md
@@ -18,7 +18,6 @@ To integrate with Poetry, a request has to made to register the site with DGT. S
 
 There are a number of required configuration options needed for the Poetry integration to work. These can be added at this path: `admin/tmgmt/translators/manage/poetry`:
 
-* Poetry service URL - the Poetry endpoint.
 * Identifier code - Unless requested otherwise, this can be `WEB`.
 * Request title prefix - The prefix agreed with DGT.
 * Site ID - The site ID agreed with DGT.
@@ -37,6 +36,7 @@ Using the runner, ensure that the following ends up in the site's `settings.php`
 
 ```
 $settings["poetry.identifier.sequence"] = getenv('POETRY_IDENTIFIER_SEQUENCE');
+$settings["poetry.service.endpoint"] = getenv('POETRY_SERVICE_ENDPOINT');
 $settings["poetry.service.username"] = getenv('POETRY_SERVICE_USERNAME');
 $settings["poetry.service.password"] = getenv('POETRY_SERVICE_PASSWORD');
 $settings["poetry.notification.username"] = getenv('POETRY_NOTIFICATION_USERNAME');
@@ -45,6 +45,7 @@ $settings["poetry.notification.password"] = getenv('POETRY_NOTIFICATION_PASSWORD
 
 Then, request Devops to fill those variables on the server with the following values:
 
+* `POETRY_SERVICE_ENDPOINT` - The Poetry endpoint URL, either for Acceptance of Production.
 * `POETRY_IDENTIFIER_SEQUENCE` - `NEXT_EUROPA_COUNTER`
 * `POETRY_SERVICE_USERNAME` - Username provided by DGT or CEM for accessing the Poetry environment.
 * `POETRY_SERVICE_PASSWORD` - Password provided by DGT or CEM for accessing the Poetry environment.
@@ -55,10 +56,8 @@ The notifications credentials should be in lowercase, limited to 15 characters a
 
 ## Development
 
-For using the Mock, enable the OE Translation Poetry Mock submodule and add the following to your settings file:
+For using the Mock, enable the OE Translation Poetry Mock submodule and ensure you have the following in your settings file:
 
 ```
-$config['tmgmt.translator.poetry']['settings']['service_wsdl'] = 'http://localhost:8080/build/poetry-mock/wsdl';
+$settings["poetry.service.endpoint"] = 'http://localhost:8080/build/poetry-mock/wsdl';
 ```
-
-This will override the Poetry endpoint (the service WSDL) with the one provided by the mock.

--- a/modules/oe_translation_poetry/config/schema/oe_translation_poetry.schema.yml
+++ b/modules/oe_translation_poetry/config/schema/oe_translation_poetry.schema.yml
@@ -24,9 +24,6 @@ field.value.poetry_request_id:
 tmgmt.translator.settings.poetry:
   type: mapping
   mapping:
-    service_wsdl:
-      type: string
-      label: The URL to the Poetry WSDL
     identifier_code:
       type: string
       label: Identifier code

--- a/modules/oe_translation_poetry/modules/oe_translation_poetry_mock/src/Controller/PoetryMockController.php
+++ b/modules/oe_translation_poetry/modules/oe_translation_poetry_mock/src/Controller/PoetryMockController.php
@@ -113,10 +113,11 @@ class PoetryMockController extends ControllerBase {
    *   An empty response.
    */
   public function server(): Response {
-    $wsdl = PoetryMock::getWsdlUrl();
     $url = Url::fromRoute('oe_translation_poetry_mock.server')->toString();
     $options = ['uri' => $url];
-    $server = new \SoapServer($wsdl, $options);
+    // Instantiate the server without WSDL because in tests it makes a request
+    // to the actual site instead of the test site instance.
+    $server = new \SoapServer(NULL, $options);
     $mock = new PoetryMock($this->fixturesGenerator);
     $server->setObject($mock);
 
@@ -256,7 +257,13 @@ class PoetryMockController extends ControllerBase {
   protected function performNotification(string $message): string {
     $settings = $this->poetry->getSettings();
     $url = Url::fromRoute('oe_translation_poetry.notifications')->setAbsolute()->toString(TRUE)->getGeneratedUrl();
-    $client = new \SoapClient($url . '?wsdl', ['cache_wsdl' => WSDL_CACHE_NONE]);
+    // Instantiate the client without WSDL because in tests it makes a request
+    // to the actual site instead of the test site instance.
+    $client = new \SoapClient(NULL, [
+      'cache_wsdl' => WSDL_CACHE_NONE,
+      'location' => $url,
+      'uri' => 'urn:OEPoetryClient',
+    ]);
     return $client->__soapCall('handle', [
       $settings['notification.username'],
       $settings['notification.password'],

--- a/modules/oe_translation_poetry/modules/oe_translation_poetry_mock/src/PoetryMock.php
+++ b/modules/oe_translation_poetry/modules/oe_translation_poetry_mock/src/PoetryMock.php
@@ -63,4 +63,14 @@ class PoetryMock {
     return Url::fromRoute('oe_translation_poetry_mock.wsdl')->setAbsolute()->toString();
   }
 
+  /**
+   * Builds the URL to the local mock Poetry Server.
+   *
+   * @return string
+   *   The URL.
+   */
+  public static function getServerUrl(): string {
+    return Url::fromRoute('oe_translation_poetry_mock.server')->setAbsolute()->toString();
+  }
+
 }

--- a/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
+++ b/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
@@ -17,6 +17,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Messenger\Messenger;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -182,10 +183,12 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
    *   The current route match.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
    *   The event dispatcher.
+   * @param \Drupal\Core\Messenger\Messenger $messenger
+   *   The messenger.
    *
    * @SuppressWarnings(PHPMD.ExcessiveParameterList)
    */
-  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, AccountProxyInterface $current_user, Poetry $poetry, LanguageManagerInterface $language_manager, AccessManagerInterface $access_manager, EntityTypeManagerInterface $entity_type_manager, RequestStack $request_stack, FormBuilderInterface $form_builder, PoetryJobQueueFactory $job_queue_factory, RouteMatchInterface $route_match, Connection $database, EventDispatcherInterface $eventDispatcher) {
+  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, AccountProxyInterface $current_user, Poetry $poetry, LanguageManagerInterface $language_manager, AccessManagerInterface $access_manager, EntityTypeManagerInterface $entity_type_manager, RequestStack $request_stack, FormBuilderInterface $form_builder, PoetryJobQueueFactory $job_queue_factory, RouteMatchInterface $route_match, Connection $database, EventDispatcherInterface $eventDispatcher, Messenger $messenger) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->currentUser = $current_user;
     $this->poetry = $poetry;
@@ -198,6 +201,7 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
     $this->currentRouteMatch = $route_match;
     $this->database = $database;
     $this->eventDispatcher = $eventDispatcher;
+    $this->messenger = $messenger;
   }
 
   /**
@@ -218,7 +222,8 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
       $container->get('oe_translation_poetry.job_queue_factory'),
       $container->get('current_route_match'),
       $container->get('database'),
-      $container->get('event_dispatcher')
+      $container->get('event_dispatcher'),
+      $container->get('messenger')
     );
   }
 
@@ -373,7 +378,7 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
     $access = $event->getAccess();
     if ($access instanceof AccessResultForbidden) {
       if ($access instanceof AccessResultReasonInterface && $access->getReason()) {
-        \Drupal::messenger()->addWarning($access->getReason());
+        $this->messenger->addWarning($access->getReason());
       }
       return;
     }
@@ -396,6 +401,7 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
     // @see oe_translation_poetry_form_tmgmt_content_translate_form_alter().
     $build['#accepted_languages'] = $accepted_languages;
     $build['#translated_languages'] = $translated_languages;
+    $build['#submitted_languages'] = $submitted_languages;
     $build['#completed_languages'] = [];
     // Load the completed jobs in the same request. For this we need to get
     // the request ID from one of the accepted jobs in order to filter the
@@ -499,6 +505,9 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
     // If we have an ongoing request, we should show the request ID to the user.
     if ($submitted_languages || $accepted_languages || $translated_languages) {
       $ongoing = array_merge($submitted_languages, $accepted_languages, $translated_languages);
+      // Set the ongoing languages on the build array for the event subscribers
+      // to access.
+      $build['#ongoing_languages'] = $ongoing;
       $job_info = reset($ongoing);
       $job = $this->entityTypeManager->getStorage('tmgmt_job')->load($job_info->tjid);
       $request_id = $job->get('poetry_request_id')->first()->getValue();
@@ -521,7 +530,7 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
           '#markup' => '<br /><br />' . $this->t('Incoming translations from ongoing requests will be synchronised with the revision of the content for which they had been requested.'),
         ];
       }
-      array_unshift($build, $provider_info);
+      $build = array_merge(['provider_info' => $provider_info], $build);
     }
 
     // If requests are waiting for translation by DGT, it is possible to
@@ -545,7 +554,7 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
     // If we reached this point, it means we cannot make any kind of request.
     $build['actions']['#access'] = FALSE;
     $message = $request_type->getMessage() ?? $this->t('No translation requests to DGT can be made until the ongoing ones have been accepted and/or translated.');
-    \Drupal::messenger()->addWarning($message);
+    $this->messenger->addWarning($message);
   }
 
   /**
@@ -619,12 +628,12 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
       catch (TMGMTException $e) {
         watchdog_exception('tmgmt', $e);
         $target_lang_name = $this->languageManager->getLanguage($langcode)->getName();
-        $this->messenger()->addError($this->t('Unable to add job item for target language %name. Make sure the source content is not empty.', ['%name' => $target_lang_name]));
+        $this->messenger->addError($this->t('Unable to add job item for target language %name. Make sure the source content is not empty.', ['%name' => $target_lang_name]));
       }
     }
 
     if (!$job_queue->getAllJobsIds()) {
-      $this->messenger()->addError('You need to select at least one extra language to add to the request.');
+      $this->messenger->addError('You need to select at least one extra language to add to the request.');
       return;
     }
 

--- a/modules/oe_translation_poetry/src/Poetry.php
+++ b/modules/oe_translation_poetry/src/Poetry.php
@@ -140,13 +140,10 @@ class Poetry implements PoetryInterface {
       'notification.username' => Settings::get('poetry.notification.username'),
       'notification.password' => Settings::get('poetry.notification.password'),
       'notification.endpoint' => Url::fromRoute('oe_translation_poetry.notifications')->setAbsolute()->toString(),
+      'service.wsdl' => Settings::get('poetry.service.endpoint'),
       'logger' => $this->loggerChannel,
       'log_level' => LogLevel::INFO,
     ];
-
-    if (isset($this->translatorSettings['service_wsdl'])) {
-      $values['service.wsdl'] = $this->translatorSettings['service_wsdl'];
-    }
 
     $this->poetryClient = new PoetryLibrary($values);
   }
@@ -246,7 +243,6 @@ class Poetry implements PoetryInterface {
       'title_prefix',
       'application_reference',
       'site_id',
-      'service_wsdl',
     ];
     $translator_settings = $this->getTranslatorSettings();
     foreach ($required as $setting) {
@@ -259,6 +255,7 @@ class Poetry implements PoetryInterface {
     $required = [
       'poetry.service.username',
       'poetry.service.password',
+      'poetry.service.endpoint',
       'poetry.notification.username',
       'poetry.notification.password',
       'poetry.identifier.sequence',

--- a/modules/oe_translation_poetry/src/PoetryTranslatorUI.php
+++ b/modules/oe_translation_poetry/src/PoetryTranslatorUI.php
@@ -24,12 +24,6 @@ class PoetryTranslatorUI extends TranslatorPluginUiBase {
 
     /** @var \Drupal\tmgmt\TranslatorInterface $translator */
     $translator = $form_state->getFormObject()->getEntity();
-    $form['service_wsdl'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Poetry Service URL'),
-      '#default_value' => $translator->getSetting('service_wsdl'),
-      '#description' => $this->t('The url to the Poetry service WSDL.'),
-    ];
     $form['identifier_code'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Identifier code'),

--- a/modules/oe_translation_poetry/tests/Functional/PoetryConfigurationTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryConfigurationTest.php
@@ -6,7 +6,6 @@ namespace Drupal\Tests\oe_translation_poetry\Functional;
 
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Url;
-use Drupal\oe_translation_poetry_mock\PoetryMock;
 
 /**
  * Tests the configuration of Poetry translators works as intended.
@@ -39,7 +38,6 @@ class PoetryConfigurationTest extends PoetryTranslationTestBase {
     /** @var \Drupal\tmgmt\TranslatorInterface $translator */
     $translator = $this->container->get('entity_type.manager')->getStorage('tmgmt_translator')->load('poetry');
     $form_values = [
-      'settings[service_wsdl]' => PoetryMock::getWsdlUrl(),
       'settings[identifier_code]' => 'testCode',
       'settings[title_prefix]' => 'testPrefix',
       'settings[site_id]' => 'testId',
@@ -150,10 +148,10 @@ class PoetryConfigurationTest extends PoetryTranslationTestBase {
     $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
     $this->assertSession()->buttonExists('Request a DGT translation for the selected languages');
 
-    // Unset the service WSDL as an example of required configuration.
+    // Unset the identifier code as an example of required configuration.
     /** @var \Drupal\tmgmt\TranslatorInterface $translator */
     $translator = $this->container->get('entity_type.manager')->getStorage('tmgmt_translator')->load('poetry');
-    $translator->setSetting('service_wsdl', NULL);
+    $translator->setSetting('identifier_code', NULL);
     $translator->save();
 
     $this->drupalGet($node->toUrl('drupal:content-translation-overview'));

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationTestBase.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationTestBase.php
@@ -64,14 +64,15 @@ class PoetryTranslationTestBase extends TranslationTestBase {
 
     // Configure the translator.
     /** @var \Drupal\tmgmt\TranslatorInterface $translator */
-    $translator = $this->container->get('entity_type.manager')->getStorage('tmgmt_translator')->load('poetry');
+    $translator = \Drupal::service('entity_type.manager')->getStorage('tmgmt_translator')->load('poetry');
     $translator->setSetting('service_wsdl', PoetryMock::getWsdlUrl());
     $translator->setSetting('title_prefix', 'OE');
     $translator->save();
 
     // Unset some services from the container to force a rebuild.
-    $this->container->set('oe_translation_poetry.client.default', NULL);
-    $this->container->set('oe_translation_poetry_mock.fixture_generator', NULL);
+    \Drupal::getContainer()->set('oe_translation_poetry.client.default', NULL);
+    \Drupal::getContainer()->set('oe_translation_poetry.client_factory', NULL);
+    \Drupal::getContainer()->set('oe_translation_poetry_mock.fixture_generator', NULL);
 
     $this->jobStorage = $this->entityTypeManager->getStorage('tmgmt_job');
     $this->fixtureGenerator = $this->container->get('oe_translation_poetry_mock.fixture_generator');

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationTestBase.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationTestBase.php
@@ -6,7 +6,6 @@ namespace Drupal\Tests\oe_translation_poetry\Functional;
 
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\node\NodeInterface;
-use Drupal\oe_translation_poetry_mock\PoetryMock;
 use Drupal\Tests\oe_translation\Functional\TranslationTestBase;
 use Drupal\Tests\oe_translation_poetry\Traits\PoetryTestTrait;
 use Drupal\tmgmt\Entity\Job;
@@ -65,7 +64,6 @@ class PoetryTranslationTestBase extends TranslationTestBase {
     // Configure the translator.
     /** @var \Drupal\tmgmt\TranslatorInterface $translator */
     $translator = \Drupal::service('entity_type.manager')->getStorage('tmgmt_translator')->load('poetry');
-    $translator->setSetting('service_wsdl', PoetryMock::getWsdlUrl());
     $translator->setSetting('title_prefix', 'OE');
     $translator->save();
 

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationUpdateRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationUpdateRequestTest.php
@@ -40,6 +40,7 @@ class PoetryTranslationUpdateRequestTest extends PoetryTranslationTestBase {
           'accepted_date' => '05/10/2020 23:59',
         ],
       ]);
+
     $this->performNotification($status_notification);
     // Refresh page and check the buttons.
     $this->drupalGet($node->toUrl('drupal:content-translation-overview'));

--- a/modules/oe_translation_poetry/tests/Traits/PoetryTestTrait.php
+++ b/modules/oe_translation_poetry/tests/Traits/PoetryTestTrait.php
@@ -52,7 +52,15 @@ trait PoetryTestTrait {
       $path = Url::fromRoute('oe_translation_poetry.notifications')->setAbsolute()->toString();
     }
 
-    $client = new \SoapClient($path . '?wsdl', ['cache_wsdl' => WSDL_CACHE_NONE]);
+    // Cannot pass directly the WSDL because it would make a request already
+    // before setting the cookie below and would hit the actual site and not
+    // the test site.
+    $client = new \SoapClient(NULL, [
+      'cache_wsdl' => WSDL_CACHE_NONE,
+      'location' => $path,
+      'uri' => 'urn:OEPoetryClient',
+    ]);
+
     if (property_exists($this, 'databasePrefix')) {
       $client->__setCookie('SIMPLETEST_USER_AGENT', drupal_generate_test_ua($this->databasePrefix));
     }

--- a/modules/oe_translation_poetry/tests/modules/oe_translation_poetry_test/src/PoetrySoapProvider.php
+++ b/modules/oe_translation_poetry/tests/modules/oe_translation_poetry_test/src/PoetrySoapProvider.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_translation_poetry_test;
 
+use Drupal\oe_translation_poetry_mock\PoetryMock;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 
@@ -35,7 +36,15 @@ class PoetrySoapProvider implements ServiceProviderInterface {
   public function register(Container $container) {
 
     $container['soap_client'] = function (Container $container) {
-      $client = new \SoapClient($container['settings']['service.wsdl'], $container['settings']['client.options']);
+      $options = [
+        'location' => PoetryMock::getServerUrl(),
+        'uri' => 'poetryMock',
+      ] + $container['settings']['client.options'];
+
+      // Cannot pass directly the WSDL because it would make a request already
+      // before setting the cookie below and would hit the actual site and not
+      // the test site.
+      $client = new \SoapClient(NULL, $options);
 
       foreach ($this->cookies as $name => $value) {
         $client->__setCookie($name, $value);

--- a/oe_translation.module
+++ b/oe_translation.module
@@ -22,6 +22,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\oe_translation\ContentEntitySource;
+use Drupal\oe_translation\FieldProcessor\AddressFieldProcessor;
 use Drupal\oe_translation\LocalTranslatorInterface;
 use Drupal\oe_translation\OeTranslationHandler;
 use Drupal\oe_translation\TranslationModerationHandler;
@@ -253,6 +254,10 @@ function oe_translation_field_info_alter(&$info) {
     // For the link field use the default field processor instead of the
     // specific Link one which doesn't allow the translation of the URI.
     $info['link']['tmgmt_field_processor'] = DefaultFieldProcessor::class;
+  }
+
+  if (isset($info['address'])) {
+    $info['address']['tmgmt_field_processor'] = AddressFieldProcessor::class;
   }
 }
 

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -43,6 +43,7 @@ commands:
       file: "build/sites/default/settings.override.php"
       text: |
         $settings["poetry.identifier.sequence"] = getenv('POETRY_IDENTIFIER_SEQUENCE');
+        $settings["poetry.service.endpoint"] = getenv('POETRY_SERVICE_ENDPOINT');
         $settings["poetry.service.username"] = getenv('POETRY_SERVICE_USERNAME');
         $settings["poetry.service.password"] = getenv('POETRY_SERVICE_PASSWORD');
         $settings["poetry.notification.username"] = getenv('POETRY_NOTIFICATION_USERNAME');
@@ -53,6 +54,7 @@ commands:
       file: "build/sites/default/settings.testing.php"
       text: |
         $settings["poetry.identifier.sequence"] = getenv('POETRY_IDENTIFIER_SEQUENCE');
+        $settings["poetry.service.endpoint"] = getenv('POETRY_SERVICE_ENDPOINT');
         $settings["poetry.service.username"] = getenv('POETRY_SERVICE_USERNAME');
         $settings["poetry.service.password"] = getenv('POETRY_SERVICE_PASSWORD');
         $settings["poetry.notification.username"] = getenv('POETRY_NOTIFICATION_USERNAME');

--- a/src/ContentEntitySource.php
+++ b/src/ContentEntitySource.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_translation;
 
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\tmgmt\JobItemInterface;
 use Drupal\tmgmt_content\Plugin\tmgmt\Source\ContentEntitySource as OriginalContentEntitySource;
@@ -48,6 +49,20 @@ class ContentEntitySource extends OriginalContentEntitySource implements Contain
       $plugin_definition,
       $container->get('oe_translation.content_entity_source_translation_info')
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function extractTranslatableData(ContentEntityInterface $entity) {
+    $data = parent::extractTranslatableData($entity);
+
+    // Set some information about the entity so others can know what this bit
+    // is dealing with in case it's an embedded entity.
+    $data['#entity_type'] = $entity->getEntityTypeId();
+    $data['#entity_bundle'] = $entity->bundle();
+
+    return $data;
   }
 
   /**

--- a/src/FieldProcessor/AddressFieldProcessor.php
+++ b/src/FieldProcessor/AddressFieldProcessor.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types = 1);
+
+
+namespace Drupal\oe_translation\FieldProcessor;
+
+use CommerceGuys\Addressing\AddressFormat\AddressFormatRepositoryInterface;
+use Drupal\address\FieldHelper;
+use Drupal\address\LabelHelper;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Render\Element;
+use Drupal\tmgmt_content\DefaultFieldProcessor;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * TMGMT field processor for the Address field type.
+ *
+ * The address field comes with different labels depending on the address format
+ * so we need to change the default property labels when we translate.
+ */
+class AddressFieldProcessor extends DefaultFieldProcessor implements ContainerInjectionInterface {
+
+  /**
+   * The address format repository.
+   *
+   * @var \CommerceGuys\Addressing\AddressFormat\AddressFormatRepositoryInterface
+   */
+  protected $addressFormatRepository;
+
+  /**
+   * AddressFieldProcessor constructor.
+   *
+   * @param \CommerceGuys\Addressing\AddressFormat\AddressFormatRepositoryInterface $addressFormatRepository
+   *   The address format repository.
+   */
+  public function __construct(AddressFormatRepositoryInterface $addressFormatRepository) {
+    $this->addressFormatRepository = $addressFormatRepository;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('address.address_format_repository')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function extractTranslatableData(FieldItemListInterface $field) {
+    $data = parent::extractTranslatableData($field);
+
+    foreach (Element::children($data) as $delta) {
+      $country_code = $field->get($delta)->country_code;
+      $address_format = $this->addressFormatRepository->get($country_code);
+      $labels = LabelHelper::getFieldLabels($address_format);
+      $processed_labels = [];
+      foreach ($labels as $address_part_name => $label) {
+        $property_name = FieldHelper::getPropertyName($address_part_name);
+        if ($property_name) {
+          $processed_labels[$property_name] = $label;
+        }
+      }
+
+      foreach ($data[$delta] as $address_part_name => &$address_part) {
+        if (isset($processed_labels[$address_part_name])) {
+          $address_part['#label'] = $processed_labels[$address_part_name];
+        }
+      }
+    }
+
+    return $data;
+  }
+
+}

--- a/tests/Behat/PoetryTranslationContext.php
+++ b/tests/Behat/PoetryTranslationContext.php
@@ -47,15 +47,14 @@ class PoetryTranslationContext extends RawDrupalContext {
   }
 
   /**
-   * Configures the Poetry mock WSDL.
+   * Configures the Poetry translator.
    *
    * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
    *   The scope.
    *
    * @BeforeScenario @poetry
    */
-  public function configureMock(BeforeScenarioScope $scope) {
-    $this->configContext->setBasicConfig('tmgmt.translator.poetry', 'settings.service_wsdl', $this->locatePath('poetry-mock/wsdl'));
+  public function configurePoetry(BeforeScenarioScope $scope) {
     $this->configContext->setBasicConfig('tmgmt.translator.poetry', 'settings.title_prefix', 'OE');
   }
 

--- a/tests/Functional/LocalTranslationTest.php
+++ b/tests/Functional/LocalTranslationTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_translation\Functional;
+
+use Drupal\Core\Url;
+use Drupal\node\Entity\Node;
+use Drupal\paragraphs\Entity\Paragraph;
+
+/**
+ * Tests the local translation capability.
+ */
+class LocalTranslationTest extends TranslationTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'address',
+    'paragraphs',
+    'entity_reference_revisions',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    // Mark the paragraph bundles translatable.
+    \Drupal::service('content_translation.manager')->setEnabled('paragraph', 'demo_paragraph_type', TRUE);
+    \Drupal::service('content_translation.manager')->setEnabled('paragraph', 'demo_inner_paragraph_type', TRUE);
+
+    // Mark the test entity reference field as embeddable for TMGMT to behave
+    // as composite entities.
+    $this->config('tmgmt_content.settings')
+      ->set('embedded_fields', [
+        'node' => [
+          'ott_content_reference' => TRUE,
+        ],
+      ])
+      ->save();
+  }
+
+  /**
+   * Tests the translation field labels and default values.
+   */
+  public function testLocalTranslationFields(): void {
+    // Create a node that we can reference.
+    /** @var \Drupal\node\NodeInterface $node */
+    $referenced_node = Node::create([
+      'type' => 'oe_demo_translatable_page',
+      'title' => 'Referenced node',
+    ]);
+    $referenced_node->save();
+
+    // Create paragraphs to reference and translate.
+    $grandchild_paragraph_one = Paragraph::create([
+      'type' => 'demo_inner_paragraph_type',
+      'ott_inner_paragraph_field' => 'grandchild field value 1',
+    ]);
+    $grandchild_paragraph_one->save();
+
+    $grandchild_paragraph_two = Paragraph::create([
+      'type' => 'demo_inner_paragraph_type',
+      'ott_inner_paragraph_field' => 'grandchild field value 2',
+    ]);
+    $grandchild_paragraph_two->save();
+
+    $child_paragraph_one = Paragraph::create([
+      'type' => 'demo_inner_paragraph_type',
+      'ott_inner_paragraph_field' => 'child field value 1',
+      'ott_inner_paragraphs' => [
+        [
+          'target_id' => $grandchild_paragraph_one->id(),
+          'target_revision_id' => $grandchild_paragraph_one->getRevisionId(),
+        ],
+        [
+          'target_id' => $grandchild_paragraph_two->id(),
+          'target_revision_id' => $grandchild_paragraph_two->getRevisionId(),
+        ],
+      ],
+    ]);
+    $child_paragraph_one->save();
+
+    $child_paragraph_two = Paragraph::create([
+      'type' => 'demo_inner_paragraph_type',
+      'ott_inner_paragraph_field' => 'child field value 2',
+    ]);
+    $child_paragraph_two->save();
+
+    $top_paragraph_one = Paragraph::create([
+      'type' => 'demo_paragraph_type',
+      'ott_top_level_paragraph_field' => 'top field value 1',
+      'ott_inner_paragraphs' => [
+        [
+          'target_id' => $child_paragraph_one->id(),
+          'target_revision_id' => $child_paragraph_one->getRevisionId(),
+        ],
+        [
+          'target_id' => $child_paragraph_two->id(),
+          'target_revision_id' => $child_paragraph_two->getRevisionId(),
+        ],
+      ],
+    ]);
+    $top_paragraph_one->save();
+
+    $top_paragraph_two = Paragraph::create([
+      'type' => 'demo_paragraph_type',
+      'ott_top_level_paragraph_field' => 'top field value 2',
+    ]);
+    $top_paragraph_two->save();
+
+    // Create a node to be translated.
+    $node = Node::create([
+      'type' => 'oe_demo_translatable_page',
+      'title' => 'Translation node',
+      'ott_top_level_paragraphs' => [
+        [
+          'target_id' => $top_paragraph_one->id(),
+          'target_revision_id' => $top_paragraph_one->getRevisionId(),
+        ],
+        [
+          'target_id' => $top_paragraph_two->id(),
+          'target_revision_id' => $top_paragraph_two->getRevisionId(),
+        ],
+      ],
+      'ott_address' => [
+        'country_code' => 'BE',
+        'given_name' => 'The first name',
+        'family_name' => 'The last name',
+        'locality' => 'Brussels',
+        'postal_code' => '1000',
+        'address_line1' => 'The street name',
+      ],
+      'ott_content_reference' => $referenced_node->id(),
+    ]);
+
+    $node->save();
+
+    $this->drupalGet(Url::fromRoute('oe_translation.permission_translator.create_local_task', [
+      'entity' => $node->id(),
+      'source' => 'en',
+      'target' => 'fr',
+      'entity_type' => 'node',
+    ]));
+
+    // Prepare the test data for each of the fields.
+    $fields = [];
+    $fields['title'] = [
+      'xpath' => "//table//th[normalize-space(text()) = 'Title']",
+      'value' => 'Translation node',
+    ];
+    $fields['address_country_code'] = [
+      'xpath' => "//table//th[normalize-space(text()) = 'Address - The two-letter country code.']",
+      'value' => 'BE',
+    ];
+    $fields['address_locality'] = [
+      'xpath' => "//table//th[normalize-space(text()) = 'Address - City']",
+      'value' => 'Brussels',
+    ];
+    $fields['address_postal_code'] = [
+      'xpath' => "//table//th[normalize-space(text()) = 'Address - Postal code']",
+      'value' => 1000,
+    ];
+    $fields['address_address_line1'] = [
+      'xpath' => "//table//th[normalize-space(text()) = 'Address - Street address']",
+      'value' => 'The street name',
+    ];
+    $fields['address_given_name'] = [
+      'xpath' => "//table//th[normalize-space(text()) = 'Address - First name']",
+      'value' => 'The first name',
+    ];
+    $fields['address_family_name'] = [
+      'xpath' => "//table//th[normalize-space(text()) = 'Address - Last name']",
+      'value' => 'The last name',
+    ];
+    $fields['ott_content_reference'] = [
+      'xpath' => "//table//th[normalize-space(text()) = 'Content reference - Title']",
+      'value' => 'Referenced node',
+    ];
+    $fields['ott_inner_paragraphs__0__ott_inner_paragraphs__0__ott_inner_paragraph_ott__0'] = [
+      'xpath' => "//table//th[normalize-space(text()) = 'Demo paragraph type (0) - Demo inner paragraph type (0) - Demo inner paragraph type (0) - Inner paragraph field']",
+      'value' => 'grandchild field value 1',
+    ];
+    $fields['ott_inner_paragraphs__0__ott_inner_paragraphs__0__ott_inner_paragraph_ott__1'] = [
+      'xpath' => "//table//th[normalize-space(text()) = 'Demo paragraph type (0) - Demo inner paragraph type (0) - Demo inner paragraph type (1) - Inner paragraph field']",
+      'value' => 'grandchild field value 2',
+    ];
+    $fields['ott_inner_paragraphs__0__ott_inner_paragraph_ott__0'] = [
+      'xpath' => "//table//th[normalize-space(text()) = 'Demo paragraph type (0) - Demo inner paragraph type (0) - Inner paragraph field']",
+      'value' => 'child field value 1',
+    ];
+    $fields['ott_inner_paragraphs__0__ott_inner_paragraph_ott__1'] = [
+      'xpath' => "//table//th[normalize-space(text()) = 'Demo paragraph type (0) - Demo inner paragraph type (1) - Inner paragraph field']",
+      'value' => 'child field value 2',
+    ];
+    $fields['ott_top_level_paragraphs__0__ott_top_level_paragraph_ott__0'] = [
+      'xpath' => "//table//th[normalize-space(text()) = 'Demo paragraph type (0) - Top level paragraph field']",
+      'value' => 'top field value 1',
+    ];
+    $fields['ott_top_level_paragraphs__1__ott_top_level_paragraph_ott__0'] = [
+      'xpath' => "//table//th[normalize-space(text()) = 'Demo paragraph type (1) - Top level paragraph field']",
+      'value' => 'top field value 2',
+    ];
+
+    foreach ($fields as $key => $data) {
+      $table_header = $this->getSession()->getPage()->find('xpath', $data['xpath']);
+      if (!$table_header) {
+        $this->fail(sprintf('The form label for the "%s" field was not found on the page.', $key));
+      }
+
+      $table = $table_header->getParent()->getParent()->getParent();
+      $element = $table->find('xpath', "//textarea[contains(@name,'[translation]')]");
+      if (!$element) {
+        $this->fail(sprintf('The translation element for the "%s" field was not found on the page.', $key));
+      }
+
+      $this->assertEquals($data['value'], $element->getText());
+    }
+  }
+
+}

--- a/tests/features/local_translations.feature
+++ b/tests/features/local_translations.feature
@@ -6,7 +6,7 @@ Feature: Local translations
 
   Scenario: Translate content.
     Given oe_demo_translatable_page content:
-      | title    | field_oe_demo_translatable_body | demo_link_field                             |
+      | title    | field_oe_demo_translatable_body | ott_demo_link_field                         |
       | My title | My body                         | Example - https://example.com, Node - /node |
     And I am logged in as a user with the "oe_translator" role
     When I visit "the content administration page"
@@ -23,17 +23,17 @@ Feature: Local translations
     When I click "Translate locally" in the "Bulgarian" row
     Then the translation form element for the "Title" field should contain "My title"
     And the translation form element for the "Body" field should contain "My body"
-    And the translation form element for the "Link Uri (1)" field should contain "https://example.com"
-    And the translation form element for the "Link Title (1)" field should contain "Example"
-    And the translation form element for the "Link Uri (2)" field should contain "/node"
-    And the translation form element for the "Link Title (2)" field should contain "Node"
+    And the translation form element for the "Link - URI (1)" field should contain "https://example.com"
+    And the translation form element for the "Link - Link text (1)" field should contain "Example"
+    And the translation form element for the "Link - URI (2)" field should contain "/node"
+    And the translation form element for the "Link - Link text (2)" field should contain "Node"
 
     When I fill in the translation form element for the "Title" field with "Bulgarian title"
     And I fill in the translation form element for the "Body" field with "Bulgarian body"
-    And I fill in the translation form element for the "Link Uri (1)" field with "https://example.com/bg"
-    And I fill in the translation form element for the "Link Title (1)" field with "Example BG"
-    And I fill in the translation form element for the "Link Uri (2)" field with "/bg/node"
-    And I fill in the translation form element for the "Link Title (2)" field with "Node BG"
+    And I fill in the translation form element for the "Link - URI (1)" field with "https://example.com/bg"
+    And I fill in the translation form element for the "Link - Link text (1)" field with "Example BG"
+    And I fill in the translation form element for the "Link - URI (2)" field with "/bg/node"
+    And I fill in the translation form element for the "Link - Link text (2)" field with "Node BG"
     # And I press "Save and come back later"
     # Then I should see "Translations of My title"
     # And I should see "Not translated" in the "Bulgarian" row
@@ -56,10 +56,10 @@ Feature: Local translations
     And I click "Translate locally" in the "Bulgarian" row
     Then the translation form element for the "Title" field should contain "Bulgarian title"
     And the translation form element for the "Body" field should contain "Bulgarian body"
-    And the translation form element for the "Link Uri (1)" field should contain "https://example.com/bg"
-    And the translation form element for the "Link Title (1)" field should contain "Example BG"
-    And the translation form element for the "Link Uri (2)" field should contain "/bg/node"
-    And the translation form element for the "Link Title (2)" field should contain "Node BG"
+    And the translation form element for the "Link - URI (1)" field should contain "https://example.com/bg"
+    And the translation form element for the "Link - Link text (1)" field should contain "Example BG"
+    And the translation form element for the "Link - URI (2)" field should contain "/bg/node"
+    And the translation form element for the "Link - Link text (2)" field should contain "Node BG"
 
     When I fill in the translation form element for the "Title" field with "Bulgarian title 2"
     And I press "Save and complete translation"

--- a/tests/modules/oe_translation_test/config/install/field.field.node.oe_demo_translatable_page.ott_address.yml
+++ b/tests/modules/oe_translation_test/config/install/field.field.node.oe_demo_translatable_page.ott_address.yml
@@ -2,25 +2,27 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.demo_link_field
+    - field.storage.node.ott_address
     - node.type.oe_demo_translatable_page
   module:
-    - link
+    - address
     - tmgmt_content
 third_party_settings:
   tmgmt_content:
     excluded: false
-id: node.oe_demo_translatable_page.demo_link_field
-field_name: demo_link_field
+id: node.oe_demo_translatable_page.ott_address
+field_name: ott_address
 entity_type: node
 bundle: oe_demo_translatable_page
-label: Link
+label: Address
 description: ''
 required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  link_type: 17
-  title: 1
-field_type: link
+  available_countries: {  }
+  langcode_override: ''
+  field_overrides: {  }
+  fields: {  }
+field_type: address

--- a/tests/modules/oe_translation_test/config/install/field.field.node.oe_demo_translatable_page.ott_content_reference.yml
+++ b/tests/modules/oe_translation_test/config/install/field.field.node.oe_demo_translatable_page.ott_content_reference.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.ott_content_reference
+    - node.type.oe_demo_translatable_page
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.oe_demo_translatable_page.ott_content_reference
+field_name: ott_content_reference
+entity_type: node
+bundle: oe_demo_translatable_page
+label: 'Content reference'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      oe_demo_translatable_page: oe_demo_translatable_page
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/tests/modules/oe_translation_test/config/install/field.field.node.oe_demo_translatable_page.ott_demo_link_field.yml
+++ b/tests/modules/oe_translation_test/config/install/field.field.node.oe_demo_translatable_page.ott_demo_link_field.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.ott_demo_link_field
+    - node.type.oe_demo_translatable_page
+  module:
+    - link
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.oe_demo_translatable_page.demo_link_field
+field_name: ott_demo_link_field
+entity_type: node
+bundle: oe_demo_translatable_page
+label: Link
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/tests/modules/oe_translation_test/config/install/field.field.node.oe_demo_translatable_page.ott_top_level_paragraphs.yml
+++ b/tests/modules/oe_translation_test/config/install/field.field.node.oe_demo_translatable_page.ott_top_level_paragraphs.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.ott_top_level_paragraphs
+    - node.type.oe_demo_translatable_page
+    - paragraphs.paragraphs_type.demo_paragraph_type
+  module:
+    - entity_reference_revisions
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.oe_demo_translatable_page.ott_top_level_paragraphs
+field_name: ott_top_level_paragraphs
+entity_type: node
+bundle: oe_demo_translatable_page
+label: 'Top level paragraphs'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      demo_paragraph_type: demo_paragraph_type
+    target_bundles_drag_drop:
+      demo_inner_paragraph_type:
+        weight: 3
+        enabled: false
+      demo_paragraph_type:
+        enabled: true
+        weight: 4
+field_type: entity_reference_revisions

--- a/tests/modules/oe_translation_test/config/install/field.field.paragraph.demo_inner_paragraph_type.ott_inner_paragraph_field.yml
+++ b/tests/modules/oe_translation_test/config/install/field.field.paragraph.demo_inner_paragraph_type.ott_inner_paragraph_field.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.ott_inner_paragraph_field
+    - paragraphs.paragraphs_type.demo_inner_paragraph_type
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: paragraph.demo_inner_paragraph_type.ott_inner_paragraph_field
+field_name: ott_inner_paragraph_field
+entity_type: paragraph
+bundle: demo_inner_paragraph_type
+label: 'Inner paragraph field'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/tests/modules/oe_translation_test/config/install/field.field.paragraph.demo_inner_paragraph_type.ott_inner_paragraphs.yml
+++ b/tests/modules/oe_translation_test/config/install/field.field.paragraph.demo_inner_paragraph_type.ott_inner_paragraphs.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.ott_inner_paragraphs
+    - paragraphs.paragraphs_type.demo_inner_paragraph_type
+    - paragraphs.paragraphs_type.demo_paragraph_type
+  module:
+    - entity_reference_revisions
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: paragraph.demo_inner_paragraph_type.ott_inner_paragraphs
+field_name: ott_inner_paragraphs
+entity_type: paragraph
+bundle: demo_inner_paragraph_type
+label: 'Inner Paragraphs'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      demo_inner_paragraph_type: demo_inner_paragraph_type
+    target_bundles_drag_drop:
+      demo_inner_paragraph_type:
+        enabled: true
+        weight: 3
+      demo_paragraph_type:
+        weight: 4
+        enabled: false
+field_type: entity_reference_revisions

--- a/tests/modules/oe_translation_test/config/install/field.field.paragraph.demo_paragraph_type.ott_inner_paragraphs.yml
+++ b/tests/modules/oe_translation_test/config/install/field.field.paragraph.demo_paragraph_type.ott_inner_paragraphs.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.ott_inner_paragraphs
+    - paragraphs.paragraphs_type.demo_inner_paragraph_type
+    - paragraphs.paragraphs_type.demo_paragraph_type
+  module:
+    - entity_reference_revisions
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: paragraph.demo_paragraph_type.ott_inner_paragraphs
+field_name: ott_inner_paragraphs
+entity_type: paragraph
+bundle: demo_paragraph_type
+label: 'Inner Paragraphs'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      demo_inner_paragraph_type: demo_inner_paragraph_type
+    target_bundles_drag_drop:
+      demo_inner_paragraph_type:
+        enabled: true
+        weight: 3
+      demo_paragraph_type:
+        weight: 4
+        enabled: false
+field_type: entity_reference_revisions

--- a/tests/modules/oe_translation_test/config/install/field.field.paragraph.demo_paragraph_type.ott_top_level_paragraph_field.yml
+++ b/tests/modules/oe_translation_test/config/install/field.field.paragraph.demo_paragraph_type.ott_top_level_paragraph_field.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.ott_top_level_paragraph_field
+    - paragraphs.paragraphs_type.demo_paragraph_type
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: paragraph.demo_paragraph_type.ott_top_level_paragraph_field
+field_name: ott_top_level_paragraph_field
+entity_type: paragraph
+bundle: demo_paragraph_type
+label: 'Top level paragraph field'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/tests/modules/oe_translation_test/config/install/field.storage.node.ott_address.yml
+++ b/tests/modules/oe_translation_test/config/install/field.storage.node.ott_address.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - address
+    - node
+id: node.ott_address
+field_name: ott_address
+entity_type: node
+type: address
+settings: {  }
+module: address
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/modules/oe_translation_test/config/install/field.storage.node.ott_content_reference.yml
+++ b/tests/modules/oe_translation_test/config/install/field.storage.node.ott_content_reference.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.ott_content_reference
+field_name: ott_content_reference
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/modules/oe_translation_test/config/install/field.storage.node.ott_demo_link_field.yml
+++ b/tests/modules/oe_translation_test/config/install/field.storage.node.ott_demo_link_field.yml
@@ -4,8 +4,8 @@ dependencies:
   module:
     - link
     - node
-id: node.demo_link_field
-field_name: demo_link_field
+id: node.ott_demo_link_field
+field_name: ott_demo_link_field
 entity_type: node
 type: link
 settings: {  }

--- a/tests/modules/oe_translation_test/config/install/field.storage.node.ott_top_level_paragraphs.yml
+++ b/tests/modules/oe_translation_test/config/install/field.storage.node.ott_top_level_paragraphs.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.ott_top_level_paragraphs
+field_name: ott_top_level_paragraphs
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/modules/oe_translation_test/config/install/field.storage.paragraph.ott_inner_paragraph_field.yml
+++ b/tests/modules/oe_translation_test/config/install/field.storage.paragraph.ott_inner_paragraph_field.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.ott_inner_paragraph_field
+field_name: ott_inner_paragraph_field
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/modules/oe_translation_test/config/install/field.storage.paragraph.ott_inner_paragraphs.yml
+++ b/tests/modules/oe_translation_test/config/install/field.storage.paragraph.ott_inner_paragraphs.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.ott_inner_paragraphs
+field_name: ott_inner_paragraphs
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/modules/oe_translation_test/config/install/field.storage.paragraph.ott_top_level_paragraph_field.yml
+++ b/tests/modules/oe_translation_test/config/install/field.storage.paragraph.ott_top_level_paragraph_field.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.ott_top_level_paragraph_field
+field_name: ott_top_level_paragraph_field
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/modules/oe_translation_test/config/install/paragraphs.paragraphs_type.demo_inner_paragraph_type.yml
+++ b/tests/modules/oe_translation_test/config/install/paragraphs.paragraphs_type.demo_inner_paragraph_type.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: demo_inner_paragraph_type
+label: 'Demo inner paragraph type'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/tests/modules/oe_translation_test/config/install/paragraphs.paragraphs_type.demo_paragraph_type.yml
+++ b/tests/modules/oe_translation_test/config/install/paragraphs.paragraphs_type.demo_paragraph_type.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: demo_paragraph_type
+label: 'Demo paragraph type'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/tests/modules/oe_translation_test/oe_translation_test.info.yml
+++ b/tests/modules/oe_translation_test/oe_translation_test.info.yml
@@ -7,3 +7,5 @@ package: Testing
 dependencies:
   - oe_translation:oe_translation
   - oe_multilingual_demo:oe_multilingual_demo
+  - address:address
+  - paragraphs:paragraphs

--- a/tests/modules/oe_translation_test/oe_translation_test.install
+++ b/tests/modules/oe_translation_test/oe_translation_test.install
@@ -6,13 +6,44 @@
  */
 
 use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\paragraphs\Entity\ParagraphsType;
+use Drupal\tmgmt\Entity\Translator;
 
 /**
  * Implements hook_uninstall().
  */
 function oe_translation_test_uninstall() {
-  $storage = FieldStorageConfig::load('node.demo_link_field');
-  if ($storage) {
-    $storage->delete();
+  // Delete the fields.
+  $fields = [
+    'node.ott_demo_link_field',
+    'node.ott_address',
+    'node.ott_content_reference',
+    'node.ott_top_level_paragraphs',
+    'node.ott_inner_paragraph_field',
+    'node.ott_top_level_paragraph_field',
+  ];
+  foreach ($fields as $field) {
+    $storage = FieldStorageConfig::load($field);
+    if ($storage) {
+      $storage->delete();
+    }
+  }
+
+  // Delete the paragraph types.
+  $types = [
+    'demo_inner_paragraph_type',
+    'demo_paragraph_type',
+  ];
+  foreach ($types as $type) {
+    $paragraph_type = ParagraphsType::load($type);
+    if ($paragraph_type) {
+      $paragraph_type->delete();
+    }
+  }
+
+  // Delete the test translator.
+  $translator = Translator::load('oe_translation_test_translator');
+  if ($translator) {
+    $translator->delete();
   }
 }


### PR DESCRIPTION
In this PR, the Poetry service endpoint configuration has been moved from Drupal configuration to a Drupal setting, read from an environment variable.

So if you upgrade to this release, ensure you add this to your `settings.php` file:

```
$settings["poetry.service.endpoint"] = getenv('POETRY_SERVICE_ENDPOINT');
```

And when deploying the site, make sure devops configures the `POETRY_SERVICE_ENDPOINT` environment variable to the correct Poetry endpoint, depending on whether the site is Acc or Prod.