### PR TITLE
OPENEUROPA-3017: Moving the Poetry endpoint to an environment variable.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ services:
     environment: &web-environment
       - DOCUMENT_ROOT=/test/oe_translation
       - POETRY_IDENTIFIER_SEQUENCE=NEXT_EUROPA_COUNTER
+      - POETRY_SERVICE_ENDPOINT=http://web:8080/build/poetry-mock/wsdl
       - POETRY_SERVICE_USERNAME=admin
       - POETRY_SERVICE_PASSWORD=admin
       - POETRY_NOTIFICATION_USERNAME=admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       # For Mac users: sudo ifconfig en0 alias 10.254.254.254 255.255.255.0
       # For Linux users: sudo ip addr add 10.254.254.254/32 dev lo label lo:1
       POETRY_IDENTIFIER_SEQUENCE: "NEXT_EUROPA_COUNTER"
+      POETRY_SERVICE_ENDPOINT: "http://localhost:8080/build/poetry-mock/wsdl"
       POETRY_SERVICE_USERNAME: "admin"
       POETRY_SERVICE_PASSWORD: "admin"
       POETRY_NOTIFICATION_USERNAME: "admin"

--- a/modules/oe_translation_poetry/README.md
+++ b/modules/oe_translation_poetry/README.md
@@ -18,7 +18,6 @@ To integrate with Poetry, a request has to made to register the site with DGT. S
 
 There are a number of required configuration options needed for the Poetry integration to work. These can be added at this path: `admin/tmgmt/translators/manage/poetry`:
 
-* Poetry service URL - the Poetry endpoint.
 * Identifier code - Unless requested otherwise, this can be `WEB`.
 * Request title prefix - The prefix agreed with DGT.
 * Site ID - The site ID agreed with DGT.
@@ -37,6 +36,7 @@ Using the runner, ensure that the following ends up in the site's `settings.php`
 
 ```
 $settings["poetry.identifier.sequence"] = getenv('POETRY_IDENTIFIER_SEQUENCE');
+$settings["poetry.service.endpoint"] = getenv('POETRY_SERVICE_ENDPOINT');
 $settings["poetry.service.username"] = getenv('POETRY_SERVICE_USERNAME');
 $settings["poetry.service.password"] = getenv('POETRY_SERVICE_PASSWORD');
 $settings["poetry.notification.username"] = getenv('POETRY_NOTIFICATION_USERNAME');
@@ -45,6 +45,7 @@ $settings["poetry.notification.password"] = getenv('POETRY_NOTIFICATION_PASSWORD
 
 Then, request Devops to fill those variables on the server with the following values:
 
+* `POETRY_SERVICE_ENDPOINT` - The Poetry endpoint URL, either for Acceptance of Production.
 * `POETRY_IDENTIFIER_SEQUENCE` - `NEXT_EUROPA_COUNTER`
 * `POETRY_SERVICE_USERNAME` - Username provided by DGT or CEM for accessing the Poetry environment.
 * `POETRY_SERVICE_PASSWORD` - Password provided by DGT or CEM for accessing the Poetry environment.
@@ -55,10 +56,8 @@ The notifications credentials should be in lowercase, limited to 15 characters a
 
 ## Development
 
-For using the Mock, enable the OE Translation Poetry Mock submodule and add the following to your settings file:
+For using the Mock, enable the OE Translation Poetry Mock submodule and ensure you have the following in your settings file:
 
 ```
-$config['tmgmt.translator.poetry']['settings']['service_wsdl'] = 'http://localhost:8080/build/poetry-mock/wsdl';
+$settings["poetry.service.endpoint"] = 'http://localhost:8080/build/poetry-mock/wsdl';
 ```
-
-This will override the Poetry endpoint (the service WSDL) with the one provided by the mock.

--- a/modules/oe_translation_poetry/config/schema/oe_translation_poetry.schema.yml
+++ b/modules/oe_translation_poetry/config/schema/oe_translation_poetry.schema.yml
@@ -24,9 +24,6 @@ field.value.poetry_request_id:
 tmgmt.translator.settings.poetry:
   type: mapping
   mapping:
-    service_wsdl:
-      type: string
-      label: The URL to the Poetry WSDL
     identifier_code:
       type: string
       label: Identifier code

--- a/modules/oe_translation_poetry/src/Poetry.php
+++ b/modules/oe_translation_poetry/src/Poetry.php
@@ -140,13 +140,10 @@ class Poetry implements PoetryInterface {
       'notification.username' => Settings::get('poetry.notification.username'),
       'notification.password' => Settings::get('poetry.notification.password'),
       'notification.endpoint' => Url::fromRoute('oe_translation_poetry.notifications')->setAbsolute()->toString(),
+      'service.wsdl' => Settings::get('poetry.service.endpoint'),
       'logger' => $this->loggerChannel,
       'log_level' => LogLevel::INFO,
     ];
-
-    if (isset($this->translatorSettings['service_wsdl'])) {
-      $values['service.wsdl'] = $this->translatorSettings['service_wsdl'];
-    }
 
     $this->poetryClient = new PoetryLibrary($values);
   }
@@ -246,7 +243,6 @@ class Poetry implements PoetryInterface {
       'title_prefix',
       'application_reference',
       'site_id',
-      'service_wsdl',
     ];
     $translator_settings = $this->getTranslatorSettings();
     foreach ($required as $setting) {
@@ -259,6 +255,7 @@ class Poetry implements PoetryInterface {
     $required = [
       'poetry.service.username',
       'poetry.service.password',
+      'poetry.service.endpoint',
       'poetry.notification.username',
       'poetry.notification.password',
       'poetry.identifier.sequence',

--- a/modules/oe_translation_poetry/src/PoetryTranslatorUI.php
+++ b/modules/oe_translation_poetry/src/PoetryTranslatorUI.php
@@ -24,12 +24,6 @@ class PoetryTranslatorUI extends TranslatorPluginUiBase {
 
     /** @var \Drupal\tmgmt\TranslatorInterface $translator */
     $translator = $form_state->getFormObject()->getEntity();
-    $form['service_wsdl'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Poetry Service URL'),
-      '#default_value' => $translator->getSetting('service_wsdl'),
-      '#description' => $this->t('The url to the Poetry service WSDL.'),
-    ];
     $form['identifier_code'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Identifier code'),

--- a/modules/oe_translation_poetry/tests/Functional/PoetryConfigurationTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryConfigurationTest.php
@@ -6,7 +6,6 @@ namespace Drupal\Tests\oe_translation_poetry\Functional;
 
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Url;
-use Drupal\oe_translation_poetry_mock\PoetryMock;
 
 /**
  * Tests the configuration of Poetry translators works as intended.
@@ -39,7 +38,6 @@ class PoetryConfigurationTest extends PoetryTranslationTestBase {
     /** @var \Drupal\tmgmt\TranslatorInterface $translator */
     $translator = $this->container->get('entity_type.manager')->getStorage('tmgmt_translator')->load('poetry');
     $form_values = [
-      'settings[service_wsdl]' => PoetryMock::getWsdlUrl(),
       'settings[identifier_code]' => 'testCode',
       'settings[title_prefix]' => 'testPrefix',
       'settings[site_id]' => 'testId',
@@ -150,10 +148,10 @@ class PoetryConfigurationTest extends PoetryTranslationTestBase {
     $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
     $this->assertSession()->buttonExists('Request a DGT translation for the selected languages');
 
-    // Unset the service WSDL as an example of required configuration.
+    // Unset the identifier code as an example of required configuration.
     /** @var \Drupal\tmgmt\TranslatorInterface $translator */
     $translator = $this->container->get('entity_type.manager')->getStorage('tmgmt_translator')->load('poetry');
-    $translator->setSetting('service_wsdl', NULL);
+    $translator->setSetting('identifier_code', NULL);
     $translator->save();
 
     $this->drupalGet($node->toUrl('drupal:content-translation-overview'));

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationTestBase.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationTestBase.php
@@ -6,7 +6,6 @@ namespace Drupal\Tests\oe_translation_poetry\Functional;
 
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\node\NodeInterface;
-use Drupal\oe_translation_poetry_mock\PoetryMock;
 use Drupal\Tests\oe_translation\Functional\TranslationTestBase;
 use Drupal\Tests\oe_translation_poetry\Traits\PoetryTestTrait;
 use Drupal\tmgmt\Entity\Job;
@@ -64,8 +63,7 @@ class PoetryTranslationTestBase extends TranslationTestBase {
 
     // Configure the translator.
     /** @var \Drupal\tmgmt\TranslatorInterface $translator */
-    $translator = $this->container->get('entity_type.manager')->getStorage('tmgmt_translator')->load('poetry');
-    $translator->setSetting('service_wsdl', PoetryMock::getWsdlUrl());
+    $translator = \Drupal::service('entity_type.manager')->getStorage('tmgmt_translator')->load('poetry');
     $translator->setSetting('title_prefix', 'OE');
     $translator->save();
 

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -43,6 +43,7 @@ commands:
       file: "build/sites/default/settings.override.php"
       text: |
         $settings["poetry.identifier.sequence"] = getenv('POETRY_IDENTIFIER_SEQUENCE');
+        $settings["poetry.service.endpoint"] = getenv('POETRY_SERVICE_ENDPOINT');
         $settings["poetry.service.username"] = getenv('POETRY_SERVICE_USERNAME');
         $settings["poetry.service.password"] = getenv('POETRY_SERVICE_PASSWORD');
         $settings["poetry.notification.username"] = getenv('POETRY_NOTIFICATION_USERNAME');
@@ -53,6 +54,7 @@ commands:
       file: "build/sites/default/settings.testing.php"
       text: |
         $settings["poetry.identifier.sequence"] = getenv('POETRY_IDENTIFIER_SEQUENCE');
+        $settings["poetry.service.endpoint"] = getenv('POETRY_SERVICE_ENDPOINT');
         $settings["poetry.service.username"] = getenv('POETRY_SERVICE_USERNAME');
         $settings["poetry.service.password"] = getenv('POETRY_SERVICE_PASSWORD');
         $settings["poetry.notification.username"] = getenv('POETRY_NOTIFICATION_USERNAME');

--- a/tests/Behat/PoetryTranslationContext.php
+++ b/tests/Behat/PoetryTranslationContext.php
@@ -47,15 +47,14 @@ class PoetryTranslationContext extends RawDrupalContext {
   }
 
   /**
-   * Configures the Poetry mock WSDL.
+   * Configures the Poetry translator.
    *
    * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
    *   The scope.
    *
    * @BeforeScenario @poetry
    */
-  public function configureMock(BeforeScenarioScope $scope) {
-    $this->configContext->setBasicConfig('tmgmt.translator.poetry', 'settings.service_wsdl', $this->locatePath('poetry-mock/wsdl'));
+  public function configurePoetry(BeforeScenarioScope $scope) {
     $this->configContext->setBasicConfig('tmgmt.translator.poetry', 'settings.title_prefix', 'OE');
   }
 


### PR DESCRIPTION
In this PR, the Poetry service endpoint configuration has been moved from Drupal configuration to a Drupal setting, read from an environment variable.

So if you upgrade to this release, ensure you add this to your `settings.php` file:

```
$settings["poetry.service.endpoint"] = getenv('POETRY_SERVICE_ENDPOINT');
```

And when deploying the site, make sure devops configures the `POETRY_SERVICE_ENDPOINT` environment variable to the correct Poetry endpoint, depending on whether the site is Acc or Prod.