### PR TITLE
OPENEUROPA-0000: Prepare release 0.7.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,23 @@
 # Changelog
 
-## [0.6.0](https://github.com/openeuropa/oe_translation/tree/0.6.0) (2020-04-23)
+## [0.7.0](https://github.com/openeuropa/oe_translation/tree/0.7.0) (2020-04-27)
+
+[Full Changelog](https://github.com/openeuropa/oe_translation/compare/0.6.0...0.7.0)
+
+**Merged pull requests:**
+
+- Bringing 0.6.0 into master [\#93](https://github.com/openeuropa/oe_translation/pull/93) ([upchuk](https://github.com/upchuk))
+- OPENEUROPA-2969: Fixing SOAP requests in tests. [\#89](https://github.com/openeuropa/oe_translation/pull/89) ([upchuk](https://github.com/upchuk))
+- OPENEUROPA-2969: Passing ongoing languages to the translation overview build [\#87](https://github.com/openeuropa/oe_translation/pull/87) ([22Alexandra](https://github.com/22Alexandra))
+- OPENEUROPA-2958: Fixing local translation titles. [\#82](https://github.com/openeuropa/oe_translation/pull/82) ([upchuk](https://github.com/upchuk))
+
+## [0.6.0](https://github.com/openeuropa/oe_translation/tree/0.6.0) (2020-04-27)
 
 [Full Changelog](https://github.com/openeuropa/oe_translation/compare/0.5.0...0.6.0)
 
 **Merged pull requests:**
 
+- OPENEUROPA-3017: Prepare release 0.6.0. [\#92](https://github.com/openeuropa/oe_translation/pull/92) ([imanoleguskiza](https://github.com/imanoleguskiza))
 - OPENEUROPA-3017: Moving the Poetry endpoint to an environment variable. [\#91](https://github.com/openeuropa/oe_translation/pull/91) ([upchuk](https://github.com/upchuk))
 
 ## [0.5.0](https://github.com/openeuropa/oe_translation/tree/0.5.0) (2020-04-08)


### PR DESCRIPTION
## OPENEUROPA
### Description

 Prepare release 0.7.0

### Change log

- Added: 
- Changed: Update changelog for 0.7.0
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

