### PR TITLE
OPENEUROPA-2984: Prevent cancelled languages from being added to extra language requests.

### DIFF
--- a/modules/oe_translation_poetry/oe_translation_poetry.module
+++ b/modules/oe_translation_poetry/oe_translation_poetry.module
@@ -101,6 +101,7 @@ function oe_translation_poetry_form_tmgmt_content_translate_form_alter(&$form, F
   $accepted_languages = $build['#accepted_languages'];
   $translated_languages = $build['#translated_languages'];
   $completed_languages = $build['#completed_languages'];
+  $cancelled_languages = $build['#cancelled_languages'];
   $languages = array_merge($accepted_languages, $translated_languages, $completed_languages);
 
   // If the user can make an update request, we need to ensure that all
@@ -138,6 +139,11 @@ function oe_translation_poetry_form_tmgmt_content_translate_form_alter(&$form, F
   // are the languages that have already been submitted so we can remove them
   // from the request we send to Poetry.
   $form_state->set('ongoing_languages', $languages);
+  // When we submit the request to add new languages, we need to also know which
+  // languages in the ongoing request have been cancelled so that we do not
+  // include them in the request for more languages. That will only be possible
+  // if we make an update request.
+  $form_state->set('cancelled_languages', $cancelled_languages);
 }
 
 /**

--- a/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
+++ b/modules/oe_translation_poetry/src/Plugin/tmgmt/Translator/PoetryTranslator.php
@@ -622,7 +622,7 @@ class PoetryTranslator extends TranslatorPluginBase implements ApplicableTransla
       // in the ongoing request when we are adding new languages to it.
       if ($extra_language_request && in_array($langcode, array_keys($cancelled_languages))) {
         $language = $this->languageManager->getLanguage($langcode);
-        $this->messenger->addWarning($this->t('Please be aware that <em>@language</em> has been skipped from the request because it was cancelled in Poetry for the ongoing request.', ['@language' => $language->getName()]));
+        $this->messenger->addWarning($this->t('Please be aware that <em>@language</em> has been skipped from the request because it was cancelled in DGT for the ongoing request.', ['@language' => $language->getName()]));
         continue;
       }
 

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationLanguageAddTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationLanguageAddTest.php
@@ -14,7 +14,7 @@ use Drupal\tmgmt\JobInterface;
 class PoetryTranslationLanguageAddTest extends PoetryTranslationTestBase {
 
   /**
-   * Tests to add a language to a request.
+   * Tests adding a language to a request.
    */
   public function testTranslationAddLanguagesRequest(): void {
     $node = $this->createNodeWithRequestedJobs([
@@ -103,21 +103,55 @@ class PoetryTranslationLanguageAddTest extends PoetryTranslationTestBase {
     // Refresh page.
     $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
 
-    // Assert button we see the update and add language buttons again.
+    // Assert that we see the update and add language buttons again.
     $this->assertSession()->buttonExists('Add extra languages to the ongoing DGT request');
     $this->assertSession()->buttonExists('Request a DGT translation update for the selected languages');
     $this->assertSession()->pageTextNotContains('No translation requests to DGT can be made until the ongoing ones have been accepted and/or translated.');
 
+    // Cancel one of the accepted languages.
+    $status_notification = $this->fixtureGenerator->statusNotification($this->defaultIdentifierInfo, 'CNL',
+      [
+        [
+          'code' => 'BG',
+        ],
+      ]);
+
+    $this->performNotification($status_notification);
+    $jobs = $this->loadJobsKeyedByLanguage();
+    $this->assertEquals(PoetryTranslator::POETRY_STATUS_CANCELLED, $jobs['bg']->get('poetry_state')->value);
+
+    // Try to add back that language, among others.
+    $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
+    $page->checkField('edit-languages-fr');
+    $page->checkField('edit-languages-bg');
+    $this->drupalPostForm(NULL, [], 'Add extra languages to the ongoing DGT request');
+
+    // Only FR should be included in the request.
+    $this->assertSession()->pageTextContains('Please be aware that Bulgarian has been skipped from the request because it was cancelled in Poetry for the ongoing request.');
+    $jobs = $this->loadJobsKeyedByLanguage();
+    $this->assertEquals(JobInterface::STATE_UNPROCESSED, $jobs['fr']->getState());
+    $this->assertEquals(PoetryTranslator::POETRY_STATUS_CANCELLED, $jobs['bg']->get('poetry_state')->value);
+
     // Send the translations for each job.
+    unset($jobs['bg']);
     $this->notifyWithDummyTranslations($jobs);
-    $this->assertJobsAreTranslated();
-    foreach ($this->loadJobsKeyedByLanguage() as $job) {
-      $this->assertEquals(PoetryTranslator::POETRY_STATUS_TRANSLATED, $job->get('poetry_state')->value);
+    foreach ($this->loadJobsKeyedByLanguage() as $langcode => $job) {
+      if ($langcode === 'bg') {
+        $this->assertEquals(PoetryTranslator::POETRY_STATUS_CANCELLED, $job->get('poetry_state')->value, sprintf('The %s job is not cancelled', $langcode));
+        continue;
+      }
+
+      if ($langcode === 'fr') {
+        // We have not approved the FR translation.
+        $this->assertTrue($job->get('poetry_state')->isEmpty(), sprintf('The %s job has been started.', $langcode));
+        continue;
+      }
+      $this->assertEquals(PoetryTranslator::POETRY_STATUS_TRANSLATED, $job->get('poetry_state')->value, sprintf('The %s job is not translated', $langcode));
     }
   }
 
   /**
-   * Tests to add a language to a request after content has been updated.
+   * Tests adding a language to a request after content has been updated.
    */
   public function testTranslationAddLanguagesRequestAfterUpdate(): void {
     $node = $this->createNodeWithRequestedJobs([

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationLanguageAddTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationLanguageAddTest.php
@@ -127,7 +127,7 @@ class PoetryTranslationLanguageAddTest extends PoetryTranslationTestBase {
     $this->drupalPostForm(NULL, [], 'Add extra languages to the ongoing DGT request');
 
     // Only FR should be included in the request.
-    $this->assertSession()->pageTextContains('Please be aware that Bulgarian has been skipped from the request because it was cancelled in Poetry for the ongoing request.');
+    $this->assertSession()->pageTextContains('Please be aware that Bulgarian has been skipped from the request because it was cancelled in DGT for the ongoing request.');
     $jobs = $this->loadJobsKeyedByLanguage();
     $this->assertEquals(JobInterface::STATE_UNPROCESSED, $jobs['fr']->getState());
     $this->assertEquals(PoetryTranslator::POETRY_STATUS_CANCELLED, $jobs['bg']->get('poetry_state')->value);


### PR DESCRIPTION
When a translation request in a certain language gets cancelled by Poetry, we should not be sending that language again for the same content (in the same request by adding it as an extra language).