### PR TITLE
EWPP-1118: Fix date renewal on Poetry requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "openeuropa/behat-transformation-context": "~0.1.2",
         "openeuropa/code-review": "~1.5.0",
         "openeuropa/drupal-core-require-dev": "^8.9",
-        "openeuropa/oe_multilingual": "dev-master",
+        "openeuropa/oe_multilingual": "^1.6",
         "openeuropa/task-runner": "~1.0.0-beta6",
         "phpunit/phpunit": "~6.0",
         "symfony/browser-kit": "~3.0||~4.0"

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
@@ -95,6 +95,8 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
     // set.
     $expected_poetry_request_id = [
       'code' => 'WEB',
+      // The year is the current date year because it's the first request we
+      // are making.
       'year' => date('Y'),
       // The number is the first number because it's the first request we are
       // making.
@@ -109,7 +111,20 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
     // Abort jobs to have the request button displayed again.
     $this->abort($jobs);
 
-    // Make a new request for the same node to check that the version increases.
+    // Update the job to make the year different on the saved job to mimic the
+    // fact that the previous job was requested in a different year so that we
+    // can assert the new requests all follow that year.
+    foreach ($jobs as $lang => $job) {
+      /** @var \Drupal\tmgmt\JobInterface $job */
+      $job = $this->jobStorage->load($job->id());
+      $values = $job->get('poetry_request_id')->first()->getValue();
+      $values['year'] = 2020;
+      $job->set('poetry_request_id', $values);
+      $job->save();
+    }
+
+    // Make a new request for the same node to check that the version increases
+    // but the year stays the same.
     $this->createInitialTranslationJobs($node, ['de' => 'German', 'fr' => 'French']);
     $jobs = [];
     /** @var \Drupal\tmgmt\JobInterface[] $jobs */
@@ -130,7 +145,9 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
     // set.
     $expected_poetry_request_id = [
       'code' => 'WEB',
-      'year' => date('Y'),
+      // The year follows the previous job year, even if we are no longer in
+      // that year.
+      'year' => 2020,
       'number' => '1000',
       // The version should increase.
       'version' => '1',
@@ -174,7 +191,9 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
     // set.
     $expected_poetry_request_id = [
       'code' => 'WEB',
-      'year' => date('Y'),
+      // The year follows the previous job year, even if we are no longer in
+      // that year.
+      'year' => 2020,
       'number' => '1000',
       // Version is reset to 0 because it's a new node.
       'version' => '0',
@@ -228,6 +247,8 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
     // set.
     $expected_poetry_request_id = [
       'code' => 'WEB',
+      // Since the part has reached 99 and a new number requested, the year
+      // can now also take the current one.
       'year' => date('Y'),
       'number' => '1001',
       'version' => '0',

--- a/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Functional/PoetryTranslationRequestTest.php
@@ -38,6 +38,20 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
     $this->jobStorage->resetCache();
     /** @var \Drupal\tmgmt\JobInterface[] $jobs */
     $jobs = $this->jobStorage->loadMultiple();
+    $expected_poetry_request_id = [
+      'code' => 'WEB',
+      // The year is the current date year because it's the first request we
+      // are making.
+      'year' => date('Y'),
+      // The number is the first number because it's the first request we are
+      // making.
+      'number' => '1000',
+      // We always start with version and part 0 in the first request.
+      'version' => '0',
+      'part' => '0',
+      'product' => 'TRA',
+    ];
+
     foreach ($jobs as $job) {
       $messages = $job->getMessages();
       $message_strings = [];
@@ -51,6 +65,7 @@ class PoetryTranslationRequestTest extends PoetryTranslationTestBase {
       ], $message_strings, sprintf('The messages of the %s job were not correct.', $job->getTargetLangcode()));
 
       $this->assertEquals(JobInterface::STATE_REJECTED, $job->getState(), sprintf('The state of the %s job was not correct.', $job->getTargetLangcode()));
+      $this->assertEquals($expected_poetry_request_id, $job->get('poetry_request_id')->first()->getValue());
     }
   }
 

--- a/modules/oe_translation_poetry/tests/Kernel/PoetryRequestTest.php
+++ b/modules/oe_translation_poetry/tests/Kernel/PoetryRequestTest.php
@@ -80,7 +80,8 @@ class PoetryRequestTest extends TranslationKernelTestBase {
     $this->assertEquals('WEB', $identifier->getCode());
     $this->assertEquals(0, $identifier->getPart());
     $this->assertEquals(0, $identifier->getVersion());
-    // The date is generated dynamically.
+    // The date is generated dynamically and it is the current year because it
+    // is the first request.
     $this->assertEquals(date('Y'), $identifier->getYear());
 
     // Simulate a previous translation for node 1.
@@ -92,6 +93,7 @@ class PoetryRequestTest extends TranslationKernelTestBase {
         'version' => '0',
         'product' => 'TRA',
         'number' => 11111,
+        // We go some years back for this simulation.
         'year' => 2018,
       ],
       'translator' => 'poetry',
@@ -119,8 +121,8 @@ class PoetryRequestTest extends TranslationKernelTestBase {
     // The part is increased by one from the previous request.
     $this->assertEquals('1', $identifier->getPart());
     $this->assertEquals('0', $identifier->getVersion());
-    // The date is generated dynamically.
-    $this->assertEquals(date('Y'), $identifier->getYear());
+    // The date is the same as before because the global number was not changed.
+    $this->assertEquals(2018, $identifier->getYear());
 
     // Delete the jobs from the system to mimic a data loss and ensure a new
     // number is requested in this case to start over.
@@ -136,6 +138,8 @@ class PoetryRequestTest extends TranslationKernelTestBase {
     $this->assertEquals('', $identifier->getNumber());
     $this->assertEquals('0', $identifier->getPart());
     $this->assertEquals('0', $identifier->getVersion());
+    // Since we are sending the sequence again for a new number, the year is
+    // also reset.
     $this->assertEquals(date('Y'), $identifier->getYear());
 
     // Create another finished translation for the first node but increase the
@@ -162,6 +166,7 @@ class PoetryRequestTest extends TranslationKernelTestBase {
     $this->assertEquals('', $identifier->getNumber());
     $this->assertEquals('0', $identifier->getPart());
     $this->assertEquals('0', $identifier->getVersion());
+    // And the year is also renewed.
     $this->assertEquals(date('Y'), $identifier->getYear());
   }
 


### PR DESCRIPTION
This PR fixes 2 things:

* Poetry requests should not change the year unless they are requesting a new number. 
* If a Poetry request is rejected (due to error or something), it should still store the request number for easy identification.