### PR TITLE
EWPP-3254: Re-opening translation if resent and prevent auto-accept/sync in this case.

### DIFF
--- a/modules/oe_translation_epoetry/oe_translation_epoetry.module
+++ b/modules/oe_translation_epoetry/oe_translation_epoetry.module
@@ -350,8 +350,22 @@ function oe_translation_epoetry_oe_translation_request_presave(TranslationReques
       TranslationRequestEpoetryInterface::STATUS_LANGUAGE_REJECTED,
       TranslationRequestEpoetryInterface::STATUS_LANGUAGE_REVIEW,
     ])) {
-      // It means at least one language is still not Cancelled or Synchronised.
+      // It means at least one language is still not Cancelled or in Review.
       $request_translated = FALSE;
+    }
+  }
+
+  if (!$request_translated && $request->getRequestStatus() === TranslationRequestRemoteInterface::STATUS_REQUEST_FINISHED) {
+    // If the request has been marked as finished BUT one of the languages
+    // becomes in Review again, we need to mark the request back to Translated.
+    // This can happen if a translation is dispatched again from ePoetry once
+    // the request has already been finished. And we do this to give the user
+    // a chance to see it and review it.
+    foreach ($languages as $language_with_status) {
+      if ($language_with_status->getStatus() === TranslationRequestEpoetryInterface::STATUS_LANGUAGE_REVIEW) {
+        $request_translated = TRUE;
+        break;
+      }
     }
   }
 

--- a/modules/oe_translation_epoetry/tests/src/FunctionalJavascript/EpoetryTranslationTest.php
+++ b/modules/oe_translation_epoetry/tests/src/FunctionalJavascript/EpoetryTranslationTest.php
@@ -2272,6 +2272,24 @@ class EpoetryTranslationTest extends TranslationTestBase {
     $this->getSession()->getPage()->find('css', 'summary')->click();
     $this->assertSession()->pageTextContains('The French translation has been automatically accepted.');
     $this->assertSession()->pageTextNotContains('The French translation has been accepted.');
+
+    // Sync the translation and assert that if we resend the translation, it
+    // doesn't get auto-accepted anymore.
+    $storage = \Drupal::entityTypeManager()->getStorage('oe_translation_request');
+    $storage->resetCache();
+    $request = $storage->load($request->id());
+    \Drupal::service('oe_translation_remote.translation_synchroniser')->synchronise($request, 'fr');
+    $storage->resetCache();
+    /** @var \Drupal\oe_translation\Entity\TranslationRequestEpoetryInterface $request */
+    $request = $storage->load($request->id());
+    $languages = $request->getTargetLanguages();
+    $this->assertEquals(TranslationRequestEpoetryInterface::STATUS_LANGUAGE_SYNCHRONISED, $languages['fr']->getStatus());
+    EpoetryTranslationMockHelper::translateRequest($request, 'fr');
+    $storage->resetCache();
+    /** @var \Drupal\oe_translation\Entity\TranslationRequestEpoetryInterface $request */
+    $request = $storage->load($request->id());
+    $languages = $request->getTargetLanguages();
+    $this->assertEquals(TranslationRequestEpoetryInterface::STATUS_LANGUAGE_REVIEW, $languages['fr']->getStatus());
   }
 
   /**
@@ -2320,6 +2338,18 @@ class EpoetryTranslationTest extends TranslationTestBase {
     $this->getSession()->getPage()->find('css', 'summary')->click();
     $this->assertSession()->pageTextContains('The Bulgarian translation has been automatically synchronised with the content.');
     $this->assertSession()->pageTextNotContains('The Bulgarian translation has been synchronised with the content.');
+
+    // Sync the translation and assert that if we resend the translation, it
+    // doesn't get auto-synced anymore.
+    $storage = \Drupal::entityTypeManager()->getStorage('oe_translation_request');
+    $storage->resetCache();
+    $request = $storage->load($request->id());
+    EpoetryTranslationMockHelper::translateRequest($request, 'bg');
+    $storage->resetCache();
+    /** @var \Drupal\oe_translation\Entity\TranslationRequestEpoetryInterface $request */
+    $request = $storage->load($request->id());
+    $languages = $request->getTargetLanguages();
+    $this->assertEquals(TranslationRequestEpoetryInterface::STATUS_LANGUAGE_REVIEW, $languages['bg']->getStatus());
   }
 
   /**
@@ -2668,8 +2698,19 @@ class EpoetryTranslationTest extends TranslationTestBase {
       $storage->resetCache();
       /** @var \Drupal\oe_translation_epoetry\TranslationRequestEpoetryInterface $request */
       $request = $storage->load($request->id());
-      // The request status has been marked as Finished.
+      // The request status has been marked as Translated if one of the
+      // languages is in Review or Finished if one of the languages is synced.
       $this->assertEquals($expected_status, $request->getRequestStatus());
+
+      if ($expected_status === TranslationRequestRemoteInterface::STATUS_REQUEST_FINISHED) {
+        // If the request was marked as Finished, resend the synced translation
+        // and assert the request was marked back to Translated.
+        EpoetryTranslationMockHelper::translateRequest($request, 'it');
+        $storage->resetCache();
+        /** @var \Drupal\oe_translation_epoetry\TranslationRequestEpoetryInterface $request */
+        $request = $storage->load($request->id());
+        $this->assertEquals(TranslationRequestRemoteInterface::STATUS_REQUEST_TRANSLATED, $request->getRequestStatus());
+      }
       $part++;
     }
   }


### PR DESCRIPTION
This fixes the case in which in a translation gets resent from ePoetry while it was already synced:

* It ensures the translation request gets marked back to Translated even if it's Finished already
* It ensures no auto-accept or auto-sync kicks in if it had already been synced.