### PR TITLE
EWPP-3743: EntityChanged validation disabling.

### DIFF
--- a/modules/oe_translation_corporate_workflow/oe_translation_corporate_workflow.module
+++ b/modules/oe_translation_corporate_workflow/oe_translation_corporate_workflow.module
@@ -390,3 +390,16 @@ function oe_translation_corporate_workflow_entity_base_field_info(EntityTypeInte
     return $fields;
   }
 }
+
+/**
+ * Implements hook_entity_type_alter().
+ */
+function oe_translation_corporate_workflow_entity_type_alter(array &$entity_types) {
+  // Swap out the default EntityChanged constraint with a custom one with
+  // different logic for corporate workflow translated entities.
+  $constraints = $entity_types['node']->getConstraints();
+  unset($constraints['EntityChanged']);
+  $constraints['CorporateWorkflowEntityChanged'] = NULL;
+  $entity_types['node']->setConstraints($constraints);
+
+}

--- a/modules/oe_translation_corporate_workflow/src/Plugin/Validation/Constraint/CorporateWorkflowEntityChangedConstraint.php
+++ b/modules/oe_translation_corporate_workflow/src/Plugin/Validation/Constraint/CorporateWorkflowEntityChangedConstraint.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\oe_translation_corporate_workflow\Plugin\Validation\Constraint;
+
+use Drupal\Core\Entity\Plugin\Validation\Constraint\EntityChangedConstraint;
+
+/**
+ * Validation constraint for the corporate workflow entity changed timestamp.
+ *
+ * @Constraint(
+ *   id = "CorporateWorkflowEntityChanged",
+ *   label = @Translation("Corporate workflow entity changed", context = "Validation"),
+ *   type = {"entity"}
+ * )
+ */
+class CorporateWorkflowEntityChangedConstraint extends EntityChangedConstraint {
+}

--- a/modules/oe_translation_corporate_workflow/src/Plugin/Validation/Constraint/CorporateWorkflowEntityChangedConstraintValidator.php
+++ b/modules/oe_translation_corporate_workflow/src/Plugin/Validation/Constraint/CorporateWorkflowEntityChangedConstraintValidator.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\oe_translation_corporate_workflow\Plugin\Validation\Constraint;
+
+use Drupal\Core\Entity\Plugin\Validation\Constraint\EntityChangedConstraintValidator;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Validates the CorporateWorkflowEntityChangedConstraint constraint.
+ */
+class CorporateWorkflowEntityChangedConstraintValidator extends EntityChangedConstraintValidator {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($entity, Constraint $constraint) {
+    if (!isset($entity)) {
+      return;
+    }
+    $workflow = \Drupal::service('content_moderation.moderation_information')->getWorkflowForEntity($entity);
+    if (!$workflow || $workflow->id() !== 'oe_corporate_workflow') {
+      // If the entity is not using the corporate workflow, we don't make any
+      // change.
+      parent::validate($entity, $constraint);
+      return;
+    }
+
+    // The following is similar to the parent, except that it does not compare
+    // the changed timestamp of translations but only of the source langauge.
+    /** @var \Drupal\Core\Entity\EntityInterface $entity */
+    if (!$entity->isNew()) {
+      $saved_entity = \Drupal::entityTypeManager()->getStorage($entity->getEntityTypeId())->loadUnchanged($entity->id());
+      if ($saved_entity) {
+        $common_translation_languages = array_intersect_key($entity->getTranslationLanguages(), $saved_entity->getTranslationLanguages());
+        foreach (array_keys($common_translation_languages) as $langcode) {
+          if (!$saved_entity->getTranslation($langcode)->isDefaultTranslation()) {
+            continue;
+          }
+          if ($saved_entity->getTranslation($langcode)->getChangedTime() > $entity->getTranslation($langcode)->getChangedTime()) {
+            $this->context->addViolation($constraint->message);
+            break;
+          }
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This PR fixes a narrow edge case that can happen due to the way we save translations onto the specific revision where it started from without making new revisions. The scenario:

1. Have a published node with a translation
2. Create a new version and start a local translation (same language) but only save it as a draft
3. Create a EN draft
4. Sync the local translation that was only saved in draft
5. Edit the EN draft and save and get the error: _The content has either been modified by another user, or you have already submitted modifications. As a result, your changes cannot be saved._

The problem is that the forward draft we created after we made the translation draft has a translation with a changed time X (carried over from the moment the node got the translation to begin with). And when we sync the translation onto the published version, that one gets a new changed date. 