### PR TITLE
EWPP-4243: Fixing multivalue translation removals.

### DIFF
--- a/modules/oe_translation_local/modules/oe_translation_multivalue/oe_translation_multivalue.module
+++ b/modules/oe_translation_local/modules/oe_translation_multivalue/oe_translation_multivalue.module
@@ -127,6 +127,12 @@ function oe_translation_multivalue_field_widget_complete_form_alter(&$field_widg
     return;
   }
 
+  if ($context['default']) {
+    // We don't want this to run on the field config form when the field is
+    // created and a default value may be set.
+    return;
+  }
+
   $id_generator = \Drupal::service('oe_translation_multivalue.translation_id_generator');
   $field_id = $items->getFieldDefinition()->getFieldStorageDefinition()->id();
   foreach ($items as $delta => $item) {

--- a/modules/oe_translation_local/tests/src/Functional/LocalTranslationsTest.php
+++ b/modules/oe_translation_local/tests/src/Functional/LocalTranslationsTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\oe_translation_local\Functional;
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Url;
 use Drupal\Tests\oe_translation\Functional\TranslationTestBase;
+use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
@@ -28,6 +29,9 @@ class LocalTranslationsTest extends TranslationTestBase {
     'entity_reference_revisions',
     'menu_link_content',
     'views',
+    // Add this module to increase coverage of features working correctly even
+    // with this enabled.
+    'oe_translation_multivalue',
   ];
 
   /**
@@ -137,6 +141,11 @@ class LocalTranslationsTest extends TranslationTestBase {
         ],
       ])
       ->save();
+
+    // Mark multivalue fields as using translation_multivalue.
+    $storage = FieldStorageConfig::load('node.ott_demo_link_field');
+    $storage->setSetting('translation_multivalue', TRUE);
+    $storage->save();
   }
 
   /**


### PR DESCRIPTION
Fixes the case in which a multivalue field has a value removed in the source and we sync the translation - the (correct) value should also be removed in the translation.

It fixes also a bug in the form for creating a field using translation multivalue.