### PR TITLE
D8AGE-290: Add translation request remote provider.

### DIFF
--- a/modules/oe_translation_cdt/config/install/core.entity_form_display.oe_translation_request.cdt.default.yml
+++ b/modules/oe_translation_cdt/config/install/core.entity_form_display.oe_translation_request.cdt.default.yml
@@ -2,34 +2,85 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.oe_translation_request.cdt.cdt_id
     - field.field.oe_translation_request.cdt.comments
     - field.field.oe_translation_request.cdt.confidentiality
     - field.field.oe_translation_request.cdt.contact_usernames
     - field.field.oe_translation_request.cdt.correlation_id
     - field.field.oe_translation_request.cdt.deliver_to
     - field.field.oe_translation_request.cdt.department
-    - field.field.oe_translation_request.cdt.cdt_id
     - field.field.oe_translation_request.cdt.phone_number
     - field.field.oe_translation_request.cdt.priority
     - field.field.oe_translation_request.cdt.request_status
     - field.field.oe_translation_request.cdt.target_languages
     - field.field.oe_translation_request.cdt.translated_data
+    - field.field.oe_translation_request.cdt.translator_provider
     - oe_translation.oe_translation_request_type.cdt
 id: oe_translation_request.cdt.default
 targetEntityType: oe_translation_request
 bundle: cdt
 mode: default
-content: {  }
+content:
+  comments:
+    type: string_textarea
+    weight: 0
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  confidentiality:
+    type: string_textfield
+    weight: 4
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  contact_usernames:
+    type: string_textfield
+    weight: 5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  deliver_to:
+    type: string_textfield
+    weight: 6
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  department:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  phone_number:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  priority:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
 hidden:
-  comments: true
-  confidentiality: true
-  contact_usernames: true
-  correlation_id: true
-  deliver_to: true
-  department: true
   cdt_id: true
-  phone_number: true
-  priority: true
+  correlation_id: true
   request_status: true
   target_languages: true
   translated_data: true
+  translator_provider: true

--- a/modules/oe_translation_cdt/config/install/core.entity_form_display.oe_translation_request.cdt.remote_translation_review.yml
+++ b/modules/oe_translation_cdt/config/install/core.entity_form_display.oe_translation_request.cdt.remote_translation_review.yml
@@ -3,18 +3,19 @@ status: true
 dependencies:
   config:
     - core.entity_form_mode.oe_translation_request.remote_translation_review
+    - field.field.oe_translation_request.cdt.cdt_id
     - field.field.oe_translation_request.cdt.comments
     - field.field.oe_translation_request.cdt.confidentiality
     - field.field.oe_translation_request.cdt.contact_usernames
     - field.field.oe_translation_request.cdt.correlation_id
     - field.field.oe_translation_request.cdt.deliver_to
     - field.field.oe_translation_request.cdt.department
-    - field.field.oe_translation_request.cdt.cdt_id
     - field.field.oe_translation_request.cdt.phone_number
     - field.field.oe_translation_request.cdt.priority
     - field.field.oe_translation_request.cdt.request_status
     - field.field.oe_translation_request.cdt.target_languages
     - field.field.oe_translation_request.cdt.translated_data
+    - field.field.oe_translation_request.cdt.translator_provider
     - oe_translation.oe_translation_request_type.cdt
 id: oe_translation_request.cdt.remote_translation_review
 targetEntityType: oe_translation_request
@@ -22,15 +23,16 @@ bundle: cdt
 mode: remote_translation_review
 content: {  }
 hidden:
+  cdt_id: true
   comments: true
   confidentiality: true
   contact_usernames: true
   correlation_id: true
   deliver_to: true
   department: true
-  cdt_id: true
   phone_number: true
   priority: true
   request_status: true
   target_languages: true
   translated_data: true
+  translator_provider: true

--- a/modules/oe_translation_cdt/config/install/core.entity_view_display.oe_translation_request.cdt.default.yml
+++ b/modules/oe_translation_cdt/config/install/core.entity_view_display.oe_translation_request.cdt.default.yml
@@ -2,18 +2,19 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.oe_translation_request.cdt.cdt_id
     - field.field.oe_translation_request.cdt.comments
     - field.field.oe_translation_request.cdt.confidentiality
     - field.field.oe_translation_request.cdt.contact_usernames
     - field.field.oe_translation_request.cdt.correlation_id
     - field.field.oe_translation_request.cdt.deliver_to
     - field.field.oe_translation_request.cdt.department
-    - field.field.oe_translation_request.cdt.cdt_id
     - field.field.oe_translation_request.cdt.phone_number
     - field.field.oe_translation_request.cdt.priority
     - field.field.oe_translation_request.cdt.request_status
     - field.field.oe_translation_request.cdt.target_languages
     - field.field.oe_translation_request.cdt.translated_data
+    - field.field.oe_translation_request.cdt.translator_provider
     - oe_translation.oe_translation_request_type.cdt
   module:
     - oe_translation_remote
@@ -22,6 +23,77 @@ targetEntityType: oe_translation_request
 bundle: cdt
 mode: default
 content:
+  cdt_id:
+    type: string
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 8
+    region: content
+  comments:
+    type: basic_string
+    label: inline
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  confidentiality:
+    type: string
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  contact_usernames:
+    type: string
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  correlation_id:
+    type: string
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 9
+    region: content
+  deliver_to:
+    type: string
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  department:
+    type: string
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  phone_number:
+    type: string
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  priority:
+    type: string
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 4
+    region: content
   target_languages:
     type: oe_translation_remote_language_list
     label: above
@@ -30,14 +102,6 @@ content:
     weight: 0
     region: content
 hidden:
-  comments: true
-  confidentiality: true
-  contact_usernames: true
-  correlation_id: true
-  deliver_to: true
-  department: true
-  cdt_id: true
-  phone_number: true
-  priority: true
   request_status: true
   translated_data: true
+  translator_provider: true

--- a/modules/oe_translation_cdt/config/install/core.entity_view_display.oe_translation_request.cdt.default.yml
+++ b/modules/oe_translation_cdt/config/install/core.entity_view_display.oe_translation_request.cdt.default.yml
@@ -23,21 +23,6 @@ targetEntityType: oe_translation_request
 bundle: cdt
 mode: default
 content:
-  cdt_id:
-    type: string
-    label: inline
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    weight: 8
-    region: content
-  comments:
-    type: basic_string
-    label: inline
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
   confidentiality:
     type: string
     label: inline
@@ -53,14 +38,6 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 6
-    region: content
-  correlation_id:
-    type: string
-    label: inline
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    weight: 9
     region: content
   deliver_to:
     type: string
@@ -102,6 +79,9 @@ content:
     weight: 0
     region: content
 hidden:
+  cdt_id: true
+  comments: true
+  correlation_id: true
   request_status: true
   translated_data: true
   translator_provider: true

--- a/modules/oe_translation_cdt/config/install/field.field.oe_translation_request.cdt.translator_provider.yml
+++ b/modules/oe_translation_cdt/config/install/field.field.oe_translation_request.cdt.translator_provider.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.oe_translation_request.translator_provider
+    - oe_translation.oe_translation_request_type.cdt
+id: oe_translation_request.cdt.translator_provider
+field_name: translator_provider
+entity_type: oe_translation_request
+bundle: cdt
+label: 'Translator provider'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:remote_translation_provider'
+  handler_settings:
+    target_bundles: null
+    auto_create: false
+field_type: entity_reference

--- a/modules/oe_translation_cdt/config/install/oe_translation.oe_translation_request_type.cdt.yml
+++ b/modules/oe_translation_cdt/config/install/oe_translation.oe_translation_request_type.cdt.yml
@@ -3,3 +3,6 @@ status: true
 dependencies: {  }
 id: cdt
 label: CDT
+third_party_settings:
+  oe_translation_remote:
+    remote_bundle: true

--- a/modules/oe_translation_cdt/config/install/oe_translation_remote.remote_translation_provider.cdt.yml
+++ b/modules/oe_translation_cdt/config/install/oe_translation_remote.remote_translation_provider.cdt.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: cdt
+label: CDT
+plugin: cdt
+plugin_configuration:
+  language_mapping: {  }
+enabled: true

--- a/modules/oe_translation_cdt/config/schema/oe_translation_cdt.schema.yml
+++ b/modules/oe_translation_cdt/config/schema/oe_translation_cdt.schema.yml
@@ -1,0 +1,10 @@
+oe_translation_remote.remote_translation_provider.plugin.cdt:
+  type: mapping
+  label: Plugin configuration for the CDT plugin
+  mapping:
+    language_mapping:
+      type: sequence
+      label: The language mapping
+      sequence:
+        type: string
+        label: The language code

--- a/modules/oe_translation_cdt/oe_translation_cdt.module
+++ b/modules/oe_translation_cdt/oe_translation_cdt.module
@@ -7,6 +7,8 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\oe_translation_cdt\TranslationRequestCdt;
 
 /**
@@ -15,5 +17,46 @@ use Drupal\oe_translation_cdt\TranslationRequestCdt;
 function oe_translation_cdt_entity_bundle_info_alter(array &$bundles): void {
   if (isset($bundles['oe_translation_request']['cdt'])) {
     $bundles['oe_translation_request']['cdt']['class'] = TranslationRequestCdt::class;
+  }
+}
+
+/**
+ * Implements hook_entity_ENTITY_TYPE_view_alter().
+ */
+function oe_translation_cdt_oe_translation_request_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
+  if ($entity->bundle() !== 'cdt') {
+    return;
+  }
+
+  /** @var \Drupal\oe_translation_cdt\TranslationRequestCdtInterface $entity */
+  if (!isset($build['meta'])) {
+    return;
+  }
+
+  $header = &$build['meta']['#header'];
+  $header['cdt_correlation_id'] = t('Correlation ID');
+  $header['cdt_permanent_id'] = t('Permanent ID');
+  $row = &$build['meta']['#rows'][0];
+
+  $row['cdt_correlation_id'] = $entity->getCorrelationId() ?? t('Not available');
+  $row['cdt_permanent_id'] = $entity->getCdtId() ?? t('Not available');
+
+  if ($entity->getComments()) {
+    $build['comment'] = [
+      '#type' => 'fieldset',
+      '#title' => t('Comment to the provider'),
+    ];
+    $build['comment'][] = [
+      '#markup' => $entity->getComments(),
+    ];
+  }
+
+  $logs = _oe_translation_create_request_logs_tables($entity);
+  if ($logs) {
+    $build['logs'] = [
+      '#type' => 'details',
+      '#title' => t('Log messages (@count)', ['@count' => count($logs['#rows'])]),
+      0 => $logs,
+    ];
   }
 }

--- a/modules/oe_translation_cdt/src/Event/CdtRequestEvent.php
+++ b/modules/oe_translation_cdt/src/Event/CdtRequestEvent.php
@@ -44,7 +44,7 @@ class CdtRequestEvent extends Event {
   }
 
   /**
-   * Returns the request object.
+   * Gets the request object.
    *
    * @return \OpenEuropa\CdtClient\Model\Request\Translation
    *   The request object.
@@ -54,7 +54,7 @@ class CdtRequestEvent extends Event {
   }
 
   /**
-   * Returns the translation request.
+   * Gets the translation request.
    *
    * @return \Drupal\oe_translation_cdt\TranslationRequestCdtInterface
    *   The translation request.

--- a/modules/oe_translation_cdt/src/Event/CdtRequestEvent.php
+++ b/modules/oe_translation_cdt/src/Event/CdtRequestEvent.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\oe_translation_cdt\Event;
+
+use Drupal\Component\EventDispatcher\Event;
+use Drupal\oe_translation_cdt\TranslationRequestCdtInterface;
+use OpenEuropa\CdtClient\Model\Request\Translation;
+
+/**
+ * Event thrown when sending out a request.
+ *
+ * Allows subscribers to make changes to the request object.
+ */
+class CdtRequestEvent extends Event {
+
+  /**
+   * The event name.
+   */
+  const NAME = 'oe_translation_cdt_request_event';
+
+  /**
+   * The request object.
+   */
+  protected Translation $request;
+
+  /**
+   * The local translation request entity.
+   */
+  protected TranslationRequestCdtInterface $translationRequest;
+
+  /**
+   * Constructs a CdtRequestEvent.
+   *
+   * @param \OpenEuropa\CdtClient\Model\Request\Translation $request
+   *   The request object.
+   * @param \Drupal\oe_translation_cdt\TranslationRequestCdtInterface $translation_request
+   *   The translation request.
+   */
+  public function __construct(Translation $request, TranslationRequestCdtInterface $translation_request) {
+    $this->request = $request;
+    $this->translationRequest = $translation_request;
+  }
+
+  /**
+   * Returns the request object.
+   *
+   * @return \OpenEuropa\CdtClient\Model\Request\Translation
+   *   The request object.
+   */
+  public function getRequest(): Translation {
+    return $this->request;
+  }
+
+  /**
+   * Returns the translation request.
+   *
+   * @return \Drupal\oe_translation_cdt\TranslationRequestCdtInterface
+   *   The translation request.
+   */
+  public function getTranslationRequest(): TranslationRequestCdtInterface {
+    return $this->translationRequest;
+  }
+
+}

--- a/modules/oe_translation_cdt/src/Plugin/RemoteTranslationProvider/Cdt.php
+++ b/modules/oe_translation_cdt/src/Plugin/RemoteTranslationProvider/Cdt.php
@@ -1,0 +1,321 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\oe_translation_cdt\Plugin\RemoteTranslationProvider;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\oe_translation\Entity\TranslationRequestLogInterface;
+use Drupal\oe_translation\Event\AvailableLanguagesAlterEvent;
+use Drupal\oe_translation\TranslationSourceManagerInterface;
+use Drupal\oe_translation_cdt\Api\CdtClient;
+use Drupal\oe_translation_cdt\Event\CdtRequestEvent;
+use Drupal\oe_translation_cdt\Mapper\DtoMapperInterface;
+use Drupal\oe_translation_cdt\TranslationRequestCdtInterface;
+use Drupal\oe_translation_remote\LanguageCheckboxesAwareTrait;
+use Drupal\oe_translation_remote\Plugin\RemoteTranslationProviderBase;
+use Drupal\oe_translation_remote\TranslationRequestRemoteInterface;
+use OpenEuropa\CdtClient\Exception\ValidationErrorsException;
+use OpenEuropa\CdtClient\Model\Response\ReferenceContact;
+use OpenEuropa\CdtClient\Model\Response\ReferenceItem;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Provides the CDT translator provider plugin.
+ *
+ * @RemoteTranslationProvider(
+ *   id = "cdt",
+ *   label = @Translation("CDT"),
+ *   description = @Translation("CDT translator provider plugin."),
+ * )
+ */
+class Cdt extends RemoteTranslationProviderBase {
+
+  use LanguageCheckboxesAwareTrait;
+
+  /**
+   * The class constructor.
+   *
+   * @param mixed[] $configuration
+   *   The configuration.
+   * @param string $plugin_id
+   *   The plugin ID.
+   * @param mixed $plugin_definition
+   *   The plugin definition.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
+   *   The language manager.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\oe_translation\TranslationSourceManagerInterface $translationSourceManager
+   *   The translation source manager.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger.
+   * @param \Drupal\oe_translation_cdt\Mapper\DtoMapperInterface $dtoMapper
+   *   The DTO mapper.
+   * @param \Drupal\oe_translation_cdt\Api\CdtClient $cdtClient
+   *   The CDT client.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state.
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *   The event dispatcher.
+   *
+   * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    LanguageManagerInterface $languageManager,
+    EntityTypeManagerInterface $entityTypeManager,
+    TranslationSourceManagerInterface $translationSourceManager,
+    MessengerInterface $messenger,
+    protected DtoMapperInterface $dtoMapper,
+    protected CdtClient $cdtClient,
+    protected StateInterface $state,
+    protected EventDispatcherInterface $eventDispatcher) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $languageManager, $entityTypeManager, $translationSourceManager, $messenger);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('language_manager'),
+      $container->get('entity_type.manager'),
+      $container->get('oe_translation.translation_source_manager'),
+      $container->get('messenger'),
+      $container->get('oe_translation_cdt.translation_request_mapper'),
+      $container->get('oe_translation_cdt.client'),
+      $container->get('state'),
+      $container->get('event_dispatcher')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return [
+      'language_mapping' => [],
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setConfiguration(array $configuration): void {
+    $default_configuration = $this->defaultConfiguration();
+    // Only include configuration that is defined in the default array.
+    $configuration = array_filter($configuration, function ($key) use ($default_configuration) {
+      return isset($default_configuration[$key]);
+    }, ARRAY_FILTER_USE_KEY);
+    $this->configuration = $configuration + $default_configuration;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form['language_mapping'] = [
+      '#title' => $this->t('Language mapping'),
+      '#type' => 'fieldset',
+    ];
+
+    foreach ($this->languageManager->getLanguages() as $language) {
+      $form['language_mapping'][$language->getId()] = [
+        '#type' => 'textfield',
+        '#title' => $language->getName(),
+        '#default_value' => $this->configuration['language_mapping'][$language->getId()] ?? strtoupper($language->getId()),
+      ];
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
+    $this->configuration['language_mapping'] = $form_state->getValue('language_mapping');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function newTranslationRequestForm(array &$form, FormStateInterface $form_state): array {
+    $languages = $this->languageManager->getLanguages();
+    $event = new AvailableLanguagesAlterEvent($languages);
+    $this->eventDispatcher->dispatch($event, AvailableLanguagesAlterEvent::NAME);
+    $this->addLanguageCheckboxes($form, $form_state, $event->getLanguages());
+
+    /** @var \Drupal\oe_translation_cdt\TranslationRequestCdtInterface $request */
+    $request = $this->entityTypeManager->getStorage('oe_translation_request')->create([
+      'bundle' => 'cdt',
+    ]);
+    $form_state->set('request', $request);
+
+    /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $form_display */
+    $form_display = $this->entityTypeManager->getStorage('entity_form_display')->load('oe_translation_request.cdt.default');
+    $form_state->set('form_display', $form_display);
+    $reference_data_object = $this->cdtClient->client()->getReferenceData();
+    $reference_data = [
+      'department' => $reference_data_object->getDepartments(),
+      'priority' => $reference_data_object->getPriorities(),
+      'confidentiality' => $reference_data_object->getConfidentialities(),
+      'deliver_to' => $reference_data_object->getContacts(),
+      'contact_usernames' => $reference_data_object->getContacts(),
+    ];
+
+    foreach ($form_display->getComponents() as $name => $component) {
+      /** @var \Drupal\Core\Field\WidgetInterface|null $widget */
+      $widget = $form_display->getRenderer($name);
+      if (!$widget) {
+        continue;
+      }
+
+      $items = $request->get($name);
+      $items->filterEmptyItems();
+      $form[$name] = $widget->form($items, $form, $form_state);
+      $form[$name]['#access'] = $items->access('edit');
+
+      if (isset($reference_data[$name]) && $component['type'] === 'string_textfield') {
+        $options = [];
+        foreach ($reference_data[$name] as $reference_item) {
+          if ($reference_item instanceof ReferenceItem) {
+            $options[$reference_item->getCode()] = $reference_item->getDescription();
+          }
+          elseif ($reference_item instanceof ReferenceContact) {
+            $options[$reference_item->getUsername()] = sprintf(
+              '%s %s (%s)',
+              $reference_item->getFirstName(),
+              $reference_item->getLastName(),
+              $reference_item->getUsername()
+            );
+          }
+        }
+
+        $form[$name]['widget'][0]['value']['#type'] = 'select';
+        $form[$name]['widget'][0]['value']['#options'] = $options;
+        $form[$name]['widget'][0]['value']['#size'] = 1;
+      }
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateRequest(array &$form, FormStateInterface $form_state): void {
+    // Validate that at least one language is selected.
+    $languages = $this->getSubmittedLanguages($form, $form_state);
+    if (!$languages) {
+      $form_state->setErrorByName('languages', $this->t('Please select at least one language.'));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitRequestToProvider(array &$form, FormStateInterface $form_state): void {
+    /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $form_display */
+    $form_display = $form_state->get('form_display');
+    $request = $form_state->get('request');
+    $form_display->extractFormValues($request, $form, $form_state);
+    $languages = $this->getSubmittedLanguages($form, $form_state);
+    $entity = $this->getEntity();
+
+    /** @var \Drupal\oe_translation_cdt\TranslationRequestCdtInterface $request */
+    $request = $this->entityTypeManager->getStorage('oe_translation_request')->create([
+      'bundle' => 'cdt',
+      'source_language_code' => $entity->language()->getId(),
+      'target_languages' => $languages,
+      'translator_provider' => $form_state->get('translator_id'),
+      'request_status' => TranslationRequestRemoteInterface::STATUS_REQUEST_REQUESTED,
+    ]);
+
+    $request->setContentEntity($entity);
+    $data = $this->translationSourceManager->extractData($entity->getUntranslated());
+    $request->setData($data);
+    $request->setComments($form_state->getValue('comments')['0']['value']);
+    $request->setPhoneNumber($form_state->getValue('phone_number')['0']['value']);
+    $request->setDepartment($form_state->getValue('department')['0']['value']);
+    $request->setPriority($form_state->getValue('priority')['0']['value']);
+    $request->setConfidentiality($form_state->getValue('confidentiality')['0']['value']);
+    $request->setDeliverTo(array_column($form_state->getValue('deliver_to'), 'value'));
+    $request->setContactUsernames(array_column($form_state->getValue('contact_usernames'), 'value'));
+    $request->save();
+
+    // Send it to CDT and update its status.
+    try {
+      $this->createAndSendRequestObject($request, $form, $form_state);
+    }
+    catch (ValidationErrorsException $exception) {
+      $request->setRequestStatus(TranslationRequestRemoteInterface::STATUS_REQUEST_FAILED);
+      $error_list = [];
+      foreach ($exception->getValidationErrors()->getErrors() as $key => $errors) {
+        $error_list[] = $this->t('Field @field: @errors', [
+          '@field' => $key,
+          '@errors' => implode(', ', $errors),
+        ]);
+      }
+      $this->messenger->addError($this->t('There was a problem with validating the CDT request. Please verify the CDT connection.'));
+      $request->log(
+        "Validation error: @message\n@fields",
+        [
+          '@message' => $exception->getValidationErrors()->getMessage(),
+          '@fields' => implode("\n", $error_list),
+        ],
+        TranslationRequestLogInterface::ERROR
+      );
+    }
+    catch (\Throwable $exception) {
+      $request->setRequestStatus(TranslationRequestRemoteInterface::STATUS_REQUEST_FAILED);
+      $this->messenger->addError($this->t('There was a problem sending the request to CDT.'));
+      $message = $exception->getMessage();
+
+      $request->log('@type: <strong>@message</strong>', [
+        '@type' => get_class($exception),
+        '@message' => $message,
+      ], TranslationRequestLogInterface::ERROR);
+    }
+    $request->save();
+  }
+
+  /**
+   * Creates and sends the request object to CDT.
+   *
+   * @param \Drupal\oe_translation_cdt\TranslationRequestCdtInterface $request
+   *   The request.
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   * @throws \OpenEuropa\CdtClient\Exception\ValidationErrorsException
+   */
+  protected function createAndSendRequestObject(TranslationRequestCdtInterface $request, array $form, FormStateInterface $form_state): void {
+
+    /** @var \OpenEuropa\CdtClient\Model\Request\Translation $dto */
+    $dto = $this->dtoMapper->convertEntityToDto($request);
+    $event = new CdtRequestEvent($dto, $request);
+    $this->eventDispatcher->dispatch($event, CdtRequestEvent::NAME);
+
+    $this->cdtClient->client()->validateTranslationRequest($dto);
+    $correlation_id = $this->cdtClient->client()->sendTranslationRequest($dto);
+    $request->setCorrelationId($correlation_id);
+    $request->setRequestStatus(TranslationRequestRemoteInterface::STATUS_REQUEST_REQUESTED);
+    $request->save();
+  }
+
+}

--- a/modules/oe_translation_cdt/src/Plugin/RemoteTranslationProvider/Cdt.php
+++ b/modules/oe_translation_cdt/src/Plugin/RemoteTranslationProvider/Cdt.php
@@ -331,7 +331,7 @@ class Cdt extends RemoteTranslationProviderBase {
 
     $this->apiWrapper->getClient()->validateTranslationRequest($dto);
     $request->log('The translation request was successfully validated.');
-    $correlation_id = $this->apiWrapper->getClient()->sendTranslationRequest($dto);
+    $correlation_id = $this->apiWrapper->getClient()->sendTranslationRequest($dto) ?: '';
     $request->log('The translation request was successfully sent to CDT with correlation ID: @correlation_id.', [
       '@correlation_id' => $correlation_id,
     ]);

--- a/modules/oe_translation_cdt/tests/src/FunctionalJavascript/TranslationProviderTest.php
+++ b/modules/oe_translation_cdt/tests/src/FunctionalJavascript/TranslationProviderTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\oe_translation_cdt\FunctionalJavascript;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\oe_translation\LanguageWithStatus;
+use Drupal\oe_translation_cdt\TranslationRequestCdtInterface;
+use Drupal\oe_translation_remote\Entity\RemoteTranslatorProvider;
+use Drupal\oe_translation_remote\TranslationRequestRemoteInterface;
+use Drupal\Tests\oe_translation\FunctionalJavascript\TranslationTestBase;
+use Drupal\Tests\oe_translation\Traits\TranslationsTestTrait;
+use Drupal\Tests\oe_translation_remote\Traits\RemoteTranslationsTestTrait;
+use Drupal\user\UserInterface;
+
+/**
+ * Tests the remote translations via CDT.
+ *
+ * @group batch2
+ */
+class TranslationProviderTest extends TranslationTestBase {
+
+  use TranslationsTestTrait;
+  use RemoteTranslationsTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'address',
+    'paragraphs',
+    'entity_reference_revisions',
+    'menu_link_content',
+    'views',
+    'oe_translation',
+    'oe_translation_test',
+    'oe_translation_remote',
+    'oe_translation_cdt',
+  ];
+
+  /**
+   * The user running the tests.
+   */
+  protected UserInterface $user;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $provider = RemoteTranslatorProvider::load('cdt');
+    assert($provider instanceof RemoteTranslatorProvider, 'The CDT provider should be enabled.');
+    $configuration = $provider->getProviderConfiguration() ?? [];
+    $configuration['language_mapping'] = [];
+    $provider->set('enabled', TRUE);
+    $provider->setProviderConfiguration($configuration);
+    $provider->save();
+
+    $this->user = $this->setUpTranslatorUser();
+    $this->drupalLogin($this->user);
+  }
+
+  /**
+   * Tests the CDT translation provider configuration form.
+   */
+  public function testCdtProviderConfiguration(): void {
+    $user = $this->drupalCreateUser([
+      'administer remote translators',
+      'access administration pages',
+      'access toolbar',
+    ]);
+    assert($user instanceof AccountInterface);
+    $this->drupalLogin($user);
+
+    $this->drupalGet('admin/structure/remote-translation-provider');
+    $this->assertSession()->pageTextContains('Remote Translator Provider entities');
+    $this->clickLink('Add Remote Translator Provider');
+    $this->getSession()->getPage()->selectFieldOption('Plugin', 'CDT');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertSession()->pageTextContains('Plugin configuration for CDT');
+
+    // Create a new CDT provider.
+    $this->getSession()->getPage()->fillField('Name', 'CDT provider');
+    $this->getSession()->getPage()->find('css', '.admin-link .link')->press();
+    $this->assertSession()->waitForField('Machine-readable name');
+    $this->getSession()->getPage()->fillField('Machine-readable name', 'cdt_provider');
+    $this->getSession()->getPage()->pressButton('Save');
+    $this->assertSession()->pageTextContains('Created the CDT provider Remote Translator Provider.');
+
+    // Make sure the configuration is saved properly.
+    $storage = \Drupal::entityTypeManager()->getStorage('remote_translation_provider');
+    $storage->resetCache();
+    $translator = $storage->load('cdt_provider');
+    $this->assertEquals('CDT provider', $translator->label());
+    $this->assertEquals('cdt', $translator->getProviderPlugin());
+    $default_language_mapping = [];
+    foreach (\Drupal::languageManager()->getLanguages() as $language) {
+      $default_language_mapping[$language->getId()] = strtoupper($language->getId());
+    }
+    $this->assertEquals([
+      'language_mapping' => $default_language_mapping,
+    ], $translator->getProviderConfiguration());
+
+    // Edit the provider.
+    $this->drupalGet($translator->toUrl('edit-form'));
+    $this->assertSession()->fieldValueEquals('Name', 'CDT provider');
+    $this->getSession()->getPage()->fillField('Name', 'CDT provider edited');
+    $this->assertSession()->fieldValueEquals('German', 'DE');
+    $this->getSession()->getPage()->fillField('German', 'TEST');
+    $this->getSession()->getPage()->pressButton('Save');
+    $this->assertSession()->pageTextContains('Saved the CDT provider edited Remote Translator Provider.');
+    $translator = \Drupal::entityTypeManager()->getStorage('remote_translation_provider')->load('cdt_provider');
+    $this->assertEquals([
+      'language_mapping' => ['de' => 'TEST'] + $default_language_mapping,
+    ], $translator->getProviderConfiguration() ?? []);
+  }
+
+  /**
+   * Tests the main remote translation flow using CDT.
+   *
+   * This is similar to RemoteTranslationTest::testSingleTranslationFlow but
+   * simplified and focusing more on the CDT specific aspects.
+   */
+  public function testCdtSingleTranslationFlow(): void {
+    // Set PT language mapping.
+    $translator = RemoteTranslatorProvider::load('cdt');
+    $configuration = $translator->getProviderConfiguration() ?? [];
+    $configuration['language_mapping']['pt-pt'] = 'PT';
+    $translator->setProviderConfiguration($configuration);
+    $translator->save();
+
+    $node = $this->createBasicTestNode('oe_demo_translatable_page', "The translation's page");
+    $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
+    $this->clickLink('Remote translations');
+
+    $select = $this->assertSession()->selectExists('Translator');
+    // The CDT translator is preselected because it's the only one.
+    $this->assertEquals('cdt', $select->find('css', 'option[selected]')->getValue());
+    $this->assertSession()->pageTextContains('New translation request using CDT');
+
+    // Select the translation settings.
+    $this->getSession()->getPage()->fillField('Comments', 'Test Translation');
+    $this->getSession()->getPage()->fillField('Confidentiality', 'CONF_1');
+    $this->getSession()->getPage()->fillField('translator_configuration[cdt][contact_usernames][0][value]', 'CONT_1');
+    $this->getSession()->getPage()->fillField('translator_configuration[cdt][deliver_to][0][value]', 'CONT_2');
+    $this->getSession()->getPage()->fillField('Department', 'DEP_1');
+    $this->getSession()->getPage()->fillField('Phone number', '12345');
+    $this->getSession()->getPage()->fillField('Priority', 'PRIO_1');
+
+    // Assert the languages' validation.
+    $this->getSession()->getPage()->pressButton('Save and send');
+    $this->assertSession()->pageTextContains('Please select at least one language.');
+
+    // Select 2 languages.
+    $this->getSession()->getPage()->checkField('Bulgarian');
+    $this->getSession()->getPage()->checkField('Portuguese');
+    $this->getSession()->getPage()->pressButton('Save and send');
+
+    $this->assertSession()->pageTextContains('The translation request has been sent to CDT.');
+
+    // Assert that we got back a correct response and our request was correctly
+    // updated.
+    $requests = \Drupal::service('plugin.manager.oe_translation_remote.remote_translation_provider_manager')->getExistingTranslationRequests($node, TRUE);
+    $this->assertCount(1, $requests);
+    $request = reset($requests);
+    $this->assertInstanceOf(TranslationRequestCdtInterface::class, $request);
+    $this->assertEquals('en', $request->getSourceLanguageCode());
+    $target_languages = $request->getTargetLanguages();
+    $this->assertEquals(new LanguageWithStatus('bg', 'Requested'), $target_languages['bg']);
+    $this->assertEquals(new LanguageWithStatus('pt-pt', 'Requested'), $target_languages['pt-pt']);
+    $this->assertEquals(TranslationRequestRemoteInterface::STATUS_LANGUAGE_REQUESTED, $request->getRequestStatus());
+    $this->assertEquals('cdt', $request->getTranslatorProvider()->id());
+
+    // Assert the log messages.
+    $expected_logs = [
+      1 => [
+        'Info',
+        'The translation request was successfully validated.',
+        $this->user->label(),
+      ],
+      2 => [
+        'Info',
+        'The translation request was successfully sent to CDT with correlation ID: ' . $request->getCorrelationId(),
+        $this->user->label(),
+      ],
+    ];
+    $this->assertLogMessagesTable($expected_logs);
+  }
+
+  /**
+   * Asserts the log messages table output.
+   *
+   * @param array $logs
+   *   The log information array keyed by the number with type and message.
+   */
+  protected function assertLogMessagesTable(array $logs): void {
+    $table = $this->getSession()->getPage()->find('css', 'table.translation-request-log-messages');
+    $rows = $table->findAll('css', 'tbody tr');
+    $this->assertCount(count($logs), $rows);
+    $actual = [];
+    foreach ($rows as $row) {
+      $cols = $row->findAll('css', 'td');
+      $actual[(int) $cols[0]->getHtml()] = [
+        $cols[1]->getHtml(),
+        strip_tags($cols[2]->getHtml()),
+        strip_tags($cols[3]->getHtml()),
+      ];
+    }
+
+    $this->assertEquals($logs, $actual);
+  }
+
+}

--- a/modules/oe_translation_cdt/tests/src/Kernel/CallbackControllerTest.php
+++ b/modules/oe_translation_cdt/tests/src/Kernel/CallbackControllerTest.php
@@ -113,10 +113,11 @@ class CallbackControllerTest extends TranslationKernelTestBase {
     $translation_request_with_id = TranslationRequest::create([
       'bundle' => 'cdt',
       'cdt_id' => '2024/12345a',
-      'cdt_status' => TranslationRequestRemoteInterface::STATUS_REQUEST_REQUESTED,
+      'request_status' => TranslationRequestRemoteInterface::STATUS_REQUEST_REQUESTED,
     ]);
-    $translation_request_with_id->save();
     assert($translation_request_with_id instanceof TranslationRequestCdtInterface);
+    $translation_request_with_id->updateTargetLanguageStatus('es', TranslationRequestRemoteInterface::STATUS_LANGUAGE_REQUESTED);
+    $translation_request_with_id->save();
     $response = $this->controller->requestStatus($request_with_id);
     $this->assertEquals(200, $response->getStatusCode(), 'The response code is not 200.');
     $translation_request_with_id = $this->reloadTranslationRequest($translation_request_with_id);
@@ -137,8 +138,10 @@ class CallbackControllerTest extends TranslationKernelTestBase {
       'cdt_status' => TranslationRequestRemoteInterface::STATUS_REQUEST_REQUESTED,
       'correlation_id' => 'bbb',
     ]);
-    $translation_request_without_id->save();
     assert($translation_request_without_id instanceof TranslationRequestCdtInterface);
+    $translation_request_without_id->updateTargetLanguageStatus('es', TranslationRequestRemoteInterface::STATUS_LANGUAGE_REQUESTED);
+    $translation_request_without_id->save();
+
     $response = $this->controller->requestStatus($request_without_id);
     $this->assertEquals(200, $response->getStatusCode(), 'The response code is not 200.');
     $translation_request_without_id = $this->reloadTranslationRequest($translation_request_without_id);


### PR DESCRIPTION
## D8AGE-290

### Description

The goal of the ticket was to add a new `Cdt.php` remote provider, that would allow us to create and send translation requests. The provider defines a form (connected to remote ReferenceData) and uses some components (`XmlFormatter`, `ApiWrapper`) from previous tickets.

