### PR TITLE
EWPP-4241: Allowing for remote translations to work without local ones.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,13 @@
         "patches": {
             "drupal/address": {
                 "https://www.drupal.org/project/address/issues/3187662": "https://www.drupal.org/files/issues/2020-12-10/3187662-3.patch"
-            }
+            },
+            "openeuropa/oe_editorial": {
+                 "latest-master": "https://github.com/openeuropa/oe_editorial/compare/2.2.0...EWPP-4233.diff"
+             },
+            "openeuropa/oe_link_lists": {
+                 "latest-master": "https://github.com/openeuropa/oe_link_lists/compare/1.2.0...EWPP-4233.diff"
+             }
         }
     },
     "config": {

--- a/modules/oe_translation_corporate_workflow/modules/oe_translation_active_revision/oe_translation_active_revision.module
+++ b/modules/oe_translation_corporate_workflow/modules/oe_translation_active_revision/oe_translation_active_revision.module
@@ -11,6 +11,7 @@ use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeInterface;
 use Drupal\oe_translation_active_revision\ActiveRevisionInterface;
 use Drupal\oe_translation_active_revision\Plugin\Field\FieldType\LanguageWithEntityRevisionItem;
 
@@ -20,9 +21,13 @@ use Drupal\oe_translation_active_revision\Plugin\Field\FieldType\LanguageWithEnt
  * @see oe_translation_corporate_workflow_form_content_moderation_entity_moderation_form_alter()
  */
 function oe_translation_active_revision_oe_translation_corporate_workflow_moderation_form_alter(array &$form, FormStateInterface $form_state) {
+  $entity = $form_state->get('entity');
+  if (!$entity instanceof NodeInterface) {
+    return;
+  }
+
   unset($form['translation_options_wrapper']['translation_drop']);
 
-  $entity = $form_state->get('entity');
   $current_state = $entity->moderation_state->value;
   if ($current_state === 'validated') {
     // If the content is already validated and only needs to be published,
@@ -287,7 +292,7 @@ function oe_translation_active_revision_entity_delete(EntityInterface $entity) {
  * Implements hook_entity_presave().
  */
 function oe_translation_active_revision_entity_presave(EntityInterface $entity): void {
-  if (!$entity instanceof ContentEntityInterface) {
+  if (!$entity instanceof NodeInterface) {
     return;
   }
 

--- a/modules/oe_translation_corporate_workflow/modules/oe_translation_active_revision/src/EventSubscriber/TranslationDashboardAlterSubscriber.php
+++ b/modules/oe_translation_corporate_workflow/modules/oe_translation_active_revision/src/EventSubscriber/TranslationDashboardAlterSubscriber.php
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
 use Drupal\oe_translation\EntityRevisionInfoInterface;
 use Drupal\oe_translation\Event\ContentTranslationDashboardAlterEvent;
 use Drupal\oe_translation_active_revision\LanguageRevisionMapping;
@@ -100,6 +101,10 @@ class TranslationDashboardAlterSubscriber implements EventSubscriberInterface {
     /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
     $entity = $event->getRouteMatch()->getParameter($event->getEntityTypeId());
     $entity = $this->entityTypeManager->getStorage($event->getEntityTypeId())->load($entity->id());
+    if (!$entity instanceof NodeInterface) {
+      // We only support nodes for the time being.
+      return;
+    }
 
     /** @var \Drupal\workflows\WorkflowInterface $workflow */
     $workflow = $this->moderationInformation->getWorkflowForEntity($entity);

--- a/modules/oe_translation_corporate_workflow/modules/oe_translation_active_revision/src/EventSubscriber/TranslationSynchronisationSubscriber.php
+++ b/modules/oe_translation_corporate_workflow/modules/oe_translation_active_revision/src/EventSubscriber/TranslationSynchronisationSubscriber.php
@@ -6,6 +6,7 @@ namespace Drupal\oe_translation_active_revision\EventSubscriber;
 
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
 use Drupal\oe_translation\EntityRevisionInfoInterface;
 use Drupal\oe_translation\Event\TranslationSynchronisationEvent;
 use Drupal\oe_translation_active_revision\Plugin\Field\FieldType\LanguageWithEntityRevisionItem;
@@ -60,6 +61,10 @@ class TranslationSynchronisationSubscriber implements EventSubscriberInterface {
    */
   public function onSync(TranslationSynchronisationEvent $event): void {
     $entity = $event->getEntity();
+    if (!$entity instanceof NodeInterface) {
+      // We only support nodes for the time being.
+      return;
+    }
     // We need to make sure we are using the entity onto which the sync would
     // take place.
     $entity = $this->entityRevisionInfo->getEntityRevision($entity, $event->getLangcode());

--- a/modules/oe_translation_corporate_workflow/oe_translation_corporate_workflow.module
+++ b/modules/oe_translation_corporate_workflow/oe_translation_corporate_workflow.module
@@ -370,6 +370,8 @@ function oe_translation_corporate_workflow_oe_translation_request_view_alter(arr
 function oe_translation_corporate_workflow_entity_base_field_info(EntityTypeInterface $entity_type) {
   if ($entity_type->id() == 'node') {
     $fields = [];
+    // By default, this is added to nodes but it needs to be added manually for
+    // any other entity types that want to use the corporate workflow.
     $fields['translation_request'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('The originating translation request'))
       ->setDescription(t('The translation request where the translation came from'))

--- a/modules/oe_translation_corporate_workflow/oe_translation_corporate_workflow.module
+++ b/modules/oe_translation_corporate_workflow/oe_translation_corporate_workflow.module
@@ -8,13 +8,14 @@
 declare(strict_types=1);
 
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\ContentEntityTypeInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\TypedData\TranslationStatusInterface;
-use Drupal\node\NodeInterface;
+use Drupal\oe_translation_corporate_workflow\Form\RevisionTranslationDeleteForm;
 
 /**
  * Implements hook_theme().
@@ -30,7 +31,11 @@ function oe_translation_corporate_workflow_theme($existing, $type, $theme, $path
 /**
  * Implements hook_ENTITY_TYPE_presave().
  */
-function oe_translation_corporate_workflow_node_presave(EntityInterface $entity): void {
+function oe_translation_corporate_workflow_entity_presave(EntityInterface $entity): void {
+  if (!$entity instanceof ContentEntityInterface) {
+    return;
+  }
+
   /** @var \Drupal\workflows\WorkflowInterface $workflow */
   $workflow = \Drupal::service('content_moderation.moderation_information')->getWorkflowForEntity($entity);
   if (!$workflow || $workflow->id() !== 'oe_corporate_workflow') {
@@ -38,7 +43,16 @@ function oe_translation_corporate_workflow_node_presave(EntityInterface $entity)
     return;
   }
 
-  // Drop the translations if we are saving a validated revision if the node
+  /** @var \Drupal\oe_translation\TranslatorProvidersInterface $translator_providers */
+  $translator_providers = \Drupal::service('oe_translation.translator_providers');
+  if (!$translator_providers->hasTranslators($entity->getEntityType())) {
+    // We only care about entities translated using our system.
+    return;
+  }
+
+  oe_translation_corporate_workflow_prevent_translation_delete_revisions($entity);
+
+  // Drop the translations if we are saving a validated revision if the entity
   // was marked for it.
   if (isset($entity->translation_drop) && $entity->translation_drop === TRUE && $entity->moderation_state->value === 'validated') {
     foreach ($entity->getTranslationLanguages(FALSE) as $langcode => $language) {
@@ -51,12 +65,18 @@ function oe_translation_corporate_workflow_node_presave(EntityInterface $entity)
   // translations. Later, we will introduce the "un-synced" translations by
   // which we will keep the translations unpublished even if the source language
   // is published.
+  if (!$entity->getEntityType()->hasKey('published')) {
+    return;
+  }
+
+  $status_field = $entity->getEntityType()->getKey('published');
+
   if (!$entity->isDefaultTranslation()) {
     // If we are saving a translation entity directly, look at the source
     // translation for the correct status.
     $source = $entity->getUntranslated();
-    if ($source->get('status')->value !== $entity->get('status')->value) {
-      $entity->set('status', $source->get('status')->value);
+    if ($source->get($status_field)->value !== $entity->get($status_field)->value) {
+      $entity->set($status_field, $source->get($status_field)->value);
     }
 
     // We need to do the same for the moderation state.
@@ -74,16 +94,16 @@ function oe_translation_corporate_workflow_node_presave(EntityInterface $entity)
   $languages = $entity->getTranslationLanguages(FALSE);
   foreach ($languages as $language) {
     $translation = $entity->getTranslation($language->getId());
-    if ($translation->get('status')->value !== $entity->get('status')->value) {
-      $translation->set('status', $entity->get('status')->value);
+    if ($translation->get($status_field)->value !== $entity->get($status_field)->value) {
+      $translation->set($status_field, $entity->get($status_field)->value);
     }
   }
 }
 
 /**
- * Implements hook_ENTITY_TYPE_view_alter() for the Node entity.
+ * Implements hook_ENTITY_TYPE_view_alter().
  */
-function oe_translation_corporate_workflow_node_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display): void {
+function oe_translation_corporate_workflow_entity_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display): void {
   /** @var \Drupal\workflows\WorkflowInterface $workflow */
   $workflow = \Drupal::service('content_moderation.moderation_information')->getWorkflowForEntity($entity);
   if (!$workflow || $workflow->id() !== 'oe_corporate_workflow') {
@@ -103,7 +123,7 @@ function oe_translation_corporate_workflow_node_view_alter(array &$build, Entity
 }
 
 /**
- * Implements hook_entity_revision_create() for the Node entity.
+ * Implements hook_entity_revision_create().
  *
  * This hook replicates to an extent a chunk of the responsibility of
  * ContentEntityStorageBase::createRevision().
@@ -131,9 +151,12 @@ function oe_translation_corporate_workflow_entity_revision_create(ContentEntityI
     return;
   }
 
-  // We only support nodes and entities that can be embedded into nodes that
-  // are using the entity reference revision parent-child relation.
-  if (!$entity instanceof NodeInterface && !$entity->getEntityType()->get('entity_revision_parent_id_field')) {
+  /** @var \Drupal\workflows\WorkflowInterface $workflow */
+  $workflow = \Drupal::service('content_moderation.moderation_information')->getWorkflowForEntity($entity);
+  if ((!$workflow || $workflow->id() !== 'oe_corporate_workflow') && !$entity->getEntityType()->get('entity_revision_parent_id_field')) {
+    // We only support corporate workflow entities and entities that can be
+    // embedded into other entities using the entity reference revision
+    // parent-child relation.
     return;
   }
 
@@ -227,13 +250,13 @@ function oe_translation_corporate_workflow_form_content_moderation_entity_modera
         ],
       ],
     ],
+    // If the content is already validated and only needs to be published,
+    // we don't show it.
+    '#access' => $current_state !== 'validated',
   ];
   $form['translation_options_wrapper']['translation_drop'] = [
     '#type' => 'checkbox',
     '#title' => t('Do not carry over the translations'),
-    // If the content is already validated and only needs to be published,
-    // we don't show it.
-    '#access' => $current_state !== 'validated',
   ];
 
   $form['#theme'] = 'entity_moderation_form__oe_translation_corporate_workflow';
@@ -290,21 +313,16 @@ function oe_translation_corporate_workflow_content_moderation_state_presave(Enti
 }
 
 /**
- * Implements hook_entity_presave().
+ * Prevents new revisions when we delete a translation from an entity.
  *
  * Whenever we delete a translation that is made using our
  * translators, we do not make a new revision of the entity. Since translations
  * are added to the same revision where they were initiated, for the same
  * reason their removal should not impact the number of entity revisions.
+ *
+ * This is called from oe_translation_corporate_workflow_entity_presave().
  */
-function oe_translation_corporate_workflow_entity_presave(EntityInterface $entity) {
-  /** @var \Drupal\oe_translation\TranslatorProvidersInterface $translator_providers */
-  $translator_providers = \Drupal::service('oe_translation.translator_providers');
-  if (!$translator_providers->hasTranslators($entity->getEntityType())) {
-    // We only care about entities translated using our system.
-    return;
-  }
-
+function oe_translation_corporate_workflow_prevent_translation_delete_revisions(ContentEntityInterface $entity) {
   if (isset($entity->translation_drop) && $entity->translation_drop === TRUE) {
     // If the translations are being dropped by the editorial carry-over logic,
     // we do not want to prevent the creation of new revisions because the use
@@ -390,11 +408,28 @@ function oe_translation_corporate_workflow_entity_base_field_info(EntityTypeInte
  * Implements hook_entity_type_alter().
  */
 function oe_translation_corporate_workflow_entity_type_alter(array &$entity_types) {
-  // Swap out the default EntityChanged constraint with a custom one with
-  // different logic for corporate workflow translated entities.
-  $constraints = $entity_types['node']->getConstraints();
-  unset($constraints['EntityChanged']);
-  $constraints['CorporateWorkflowEntityChanged'] = NULL;
-  $entity_types['node']->setConstraints($constraints);
+  /** @var \Drupal\Core\Entity\EntityTypeInterface $entity_type */
+  foreach ($entity_types as $entity_type_id => $entity_type) {
+    if (!$entity_type instanceof ContentEntityTypeInterface) {
+      continue;
+    }
 
+    // Swap out the revision delete form class.
+    if ($entity_type->getFormClass('revision-delete')) {
+      // This changes for most entity types, except for nodes which is a route
+      // _form class changed in the route subscriber.
+      $entity_type->setFormClass('revision-delete', RevisionTranslationDeleteForm::class);
+    }
+
+    // Swap out the default EntityChanged constraint with a custom one with
+    // different logic for corporate workflow translated entities. We can do
+    // this for all entity types because the override will only apply to the
+    // corporate workflow ones.
+    $constraints = $entity_type->getConstraints();
+    if (array_key_exists('EntityChanged', $constraints)) {
+      unset($constraints['EntityChanged']);
+      $constraints['CorporateWorkflowEntityChanged'] = NULL;
+      $entity_type->setConstraints($constraints);
+    }
+  }
 }

--- a/modules/oe_translation_corporate_workflow/src/EventSubscriber/TranslationDashboardAlterSubscriber.php
+++ b/modules/oe_translation_corporate_workflow/src/EventSubscriber/TranslationDashboardAlterSubscriber.php
@@ -395,9 +395,7 @@ class TranslationDashboardAlterSubscriber implements EventSubscriberInterface {
       return [];
     }
 
-    if (!$default && !$translation instanceof NodeInterface) {
-      // We only support the operations for non default revisions for Node
-      // entities.
+    if (!$default && !$translation) {
       return [];
     }
 
@@ -413,13 +411,20 @@ class TranslationDashboardAlterSubscriber implements EventSubscriberInterface {
 
     $delete = $translation->toUrl('delete-form');
     if (!$default) {
-      $delete = Url::fromRoute('node.revision_delete_confirm', [
-        'node' => $translation->id(),
-        'node_revision' => $translation->getRevisionId(),
-      ], [
-        'language' => $translation->language(),
-        'query' => ['destination' => Url::fromRoute('<current>')->toString()],
-      ]);
+      if ($translation instanceof NodeInterface) {
+        // Nodes have a specific route for the revision delete.
+        $delete = Url::fromRoute('node.revision_delete_confirm', [
+          'node' => $translation->id(),
+          'node_revision' => $translation->getRevisionId(),
+        ], [
+          'language' => $translation->language(),
+          'query' => ['destination' => Url::fromRoute('<current>')->toString()],
+        ]);
+      }
+      else {
+        $delete = $translation->toUrl('revision-delete-form');
+        $delete->setOption('query', ['destination' => Url::fromRoute('<current>')->toString()]);
+      }
     }
     if ($delete->access() && !$translation->isDefaultTranslation()) {
       // We don't want to present a link to delete the original translation.

--- a/modules/oe_translation_corporate_workflow/src/Routing/RouteSubscriber.php
+++ b/modules/oe_translation_corporate_workflow/src/Routing/RouteSubscriber.php
@@ -61,7 +61,9 @@ class RouteSubscriber extends RouteSubscriberBase {
       }
     }
 
-    // Switch out the node revision delete confirm route.
+    // Switch out the node revision delete for (which is different than for
+    // other entities). For other entity types, it's a form class.
+    // @see oe_translation_corporate_workflow_entity_type_alter().
     $route = $collection->get('node.revision_delete_confirm');
     if ($route) {
       $defaults = $route->getDefaults();

--- a/modules/oe_translation_corporate_workflow/tests/modules/oe_translation_corporate_workflow_test/config/install/language.content_settings.link_list.dynamic.yml
+++ b/modules/oe_translation_corporate_workflow/tests/modules/oe_translation_corporate_workflow_test/config/install/language.content_settings.link_list.dynamic.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - oe_link_lists.link_list_type.dynamic
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
+id: link_list.dynamic
+target_entity_type_id: link_list
+target_bundle: dynamic
+default_langcode: site_default
+language_alterable: true

--- a/modules/oe_translation_corporate_workflow/tests/modules/oe_translation_corporate_workflow_test/oe_translation_corporate_workflow_test.info.yml
+++ b/modules/oe_translation_corporate_workflow/tests/modules/oe_translation_corporate_workflow_test/oe_translation_corporate_workflow_test.info.yml
@@ -7,3 +7,5 @@ core_version_requirement: ^10
 dependencies:
   - oe_editorial_workflow_demo:oe_editorial_workflow_demo
   - paragraphs:paragraphs
+  - oe_link_lists:oe_link_lists
+  - oe_link_lists:oe_link_lists_test

--- a/modules/oe_translation_corporate_workflow/tests/modules/oe_translation_corporate_workflow_test/oe_translation_corporate_workflow_test.install
+++ b/modules/oe_translation_corporate_workflow/tests/modules/oe_translation_corporate_workflow_test/oe_translation_corporate_workflow_test.install
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * OpenEuropa Translation Corporate Workflow Test install file.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Implements hook_install().
+ */
+function oe_translation_corporate_workflow_test_install($is_syncing): void {
+  // If we are installing from config, we bail out.
+  if ($is_syncing) {
+    return;
+  }
+
+  $corporate_workflow = \Drupal::entityTypeManager()->getStorage('workflow')->load('oe_corporate_workflow');
+  $corporate_workflow->getTypePlugin()->addEntityTypeAndBundle('link_list', 'dynamic');
+  $corporate_workflow->save();
+
+  // Install the entity version.
+  $default_values = [
+    'major' => 0,
+    'minor' => 1,
+    'patch' => 0,
+  ];
+  \Drupal::service('entity_version.entity_version_installer')->install('link_list', ['dynamic'], $default_values);
+
+  // We apply the entity version setting for the version field.
+  \Drupal::entityTypeManager()->getStorage('entity_version_settings')->create([
+    'target_entity_type_id' => 'link_list',
+    'target_bundle' => 'dynamic',
+    'target_field' => 'version',
+  ])->save();
+}

--- a/modules/oe_translation_corporate_workflow/tests/modules/oe_translation_corporate_workflow_test/oe_translation_corporate_workflow_test.module
+++ b/modules/oe_translation_corporate_workflow/tests/modules/oe_translation_corporate_workflow_test/oe_translation_corporate_workflow_test.module
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @file
+ * OpenEuropa Translation Corporate Workflow Test module file.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+
+/**
+ * Implements hook_entity_type_alter().
+ */
+function oe_translation_corporate_workflow_test_entity_type_alter(array &$entity_types) {
+  /** @var \Drupal\Core\Entity\EntityTypeInterface $entity_type */
+  foreach ($entity_types as $entity_type_id => $entity_type) {
+    if ($entity_type_id === 'link_list') {
+      // Make the link list translatable.
+      $translators = [
+        'local' => TRUE,
+      ];
+
+      $entity_type->set('oe_translation_translators', $translators);
+    }
+  }
+}
+
+/**
+ * Implements hook_entity_base_field_info().
+ */
+function oe_translation_corporate_workflow_test_entity_base_field_info(EntityTypeInterface $entity_type) {
+  if ($entity_type->id() == 'link_list') {
+    $fields = [];
+    $fields['translation_request'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('The originating translation request'))
+      ->setDescription(t('The translation request where the translation came from'))
+      ->setSetting('target_type', 'oe_translation_request')
+      ->setRevisionable(TRUE)
+      ->setTranslatable(TRUE);
+
+    return $fields;
+  }
+}

--- a/modules/oe_translation_corporate_workflow/tests/src/FunctionalJavascript/CorporateWorkflowTranslationDropTest.php
+++ b/modules/oe_translation_corporate_workflow/tests/src/FunctionalJavascript/CorporateWorkflowTranslationDropTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Drupal\Tests\oe_translation_corporate_workflow\FunctionalJavascript;
 
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+use Drupal\oe_link_lists\Entity\LinkList;
 use Drupal\Tests\oe_editorial\Traits\BatchTrait;
 use Drupal\Tests\oe_translation\Traits\TranslationsTestTrait;
+use Drupal\user\Entity\Role;
 
 /**
  * Tests the translation drop capability.
@@ -42,6 +44,7 @@ class CorporateWorkflowTranslationDropTest extends WebDriverTestBase {
     'oe_editorial_workflow_demo',
     'oe_translation',
     'oe_translation_corporate_workflow',
+    'oe_translation_corporate_workflow_test',
     'oe_translation_local',
   ];
 
@@ -86,6 +89,12 @@ class CorporateWorkflowTranslationDropTest extends WebDriverTestBase {
       $user->addRole($role);
       $user->save();
     }
+    // Add the permission to manage link lists.
+    $role = Role::load('oe_author');
+    $role->grantPermission('administer link_lists');
+    $role->grantPermission('access link list canonical page');
+    $role->grantPermission('view unpublished link list');
+    $role->save();
     $this->drupalLogin($user);
   }
 
@@ -93,132 +102,175 @@ class CorporateWorkflowTranslationDropTest extends WebDriverTestBase {
    * Tests that translations can be dropped when validating content.
    */
   public function testTranslationRevisionsDropDefault(): void {
-    /** @var \Drupal\node\NodeStorageInterface $node_storage */
-    $node_storage = $this->entityTypeManager->getStorage('node');
-
-    // Create a node and translate it.
-    /** @var \Drupal\node\NodeInterface $node */
-    $node = $node_storage->create([
-      'type' => 'page',
-      'title' => 'My node',
-      'moderation_state' => 'draft',
-    ]);
-    $node->save();
-    $this->assertRevisions('node', 1);
-    $this->assertRevisions('content_moderation_state', 1);
-
-    $this->drupalGet($node->toUrl());
-
-    // There should be no checkbox to drop languages as we don't have any
-    // translations.
-    $this->assertSession()->selectExists('Change to');
-    $this->assertSession()->fieldNotExists('Do not carry over the translations');
-
-    // Publish the content. We use the shortcuts for that.
-    $this->getSession()->getPage()->selectFieldOption('Change to', 'published');
-    $this->getSession()->getPage()->pressButton('Apply');
-    $this->waitForBatchExecution();
-    $this->assertSession()->waitForText('The moderation state has been updated.');
-
-    // We have 5 revisions all the way to published.
-    $this->assertRevisions('node', 5);
-    $this->assertRevisions('content_moderation_state', 5);
-
-    // Translate the content.
-    $node_storage->resetCache();
-    $node = $node_storage->load($node->id());
-    $request = $this->createLocalTranslationRequest($node, 'fr');
-    $this->drupalGet($request->toUrl('local-translation'));
-    $this->assertSession()->elementContains('css', '#edit-title0value-translation', 'My node');
-    $values = [
-      'Translation' => 'My node FR',
+    $title_fields = [
+      'node' => 'title',
+      'link_list' => 'administrative_title',
     ];
-    $this->submitForm($values, 'Save and synchronise');
+    foreach (['node', 'link_list'] as $entity_type) {
+      $storage = \Drupal::entityTypeManager()->getStorage($entity_type);
+      switch ($entity_type) {
 
-    // We still only have 5 revisions of each and only the published one has a
-    // translation.
-    $this->assertRevisions('node', 5, [5]);
-    $this->assertRevisions('content_moderation_state', 5, [5]);
+        case 'node':
+          $entity = $storage->create([
+            'type' => 'page',
+            'title' => 'My editorial content',
+            'moderation_state' => 'draft',
+          ]);
+          $entity->save();
+          break;
 
-    // Assert the translation overview page shows the FR translation link.
-    $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
-    $this->assertSession()->linkExistsExact('My node');
-    $this->assertEquals('Version 1.0.0', $this->getSession()->getPage()->find('xpath', '//tr[@hreflang="fr"]/td[2]')->getText());
-    $this->assertDashboardExistingTranslations([
-      'en' => ['title' => 'My node'],
-      'fr' => ['title' => 'Version 1.0.0'],
-    ]);
+        case 'link_list':
+          $entity = LinkList::create([
+            'bundle' => 'dynamic',
+            'administrative_title' => 'My editorial content',
+            'moderation_state' => 'draft',
+          ]);
 
-    // Create a new draft.
-    $node_storage->resetCache();
-    $node = $node_storage->load($node->id());
-    $node->set('title', 'My node 2');
-    $node->set('moderation_state', 'draft');
-    $node->save();
+          $configuration = [
+            'source' => [
+              'plugin' => 'test_example_source',
+              'plugin_configuration' => [
+                'entity_type' => 'node',
+                'bundle' => 'page',
+              ],
+            ],
+            'display' => [
+              'plugin' => 'title',
+            ],
+            'no_results_behaviour' => [
+              'plugin' => 'hide_list',
+              'plugin_configuration' => [],
+            ],
+            'size' => 1,
+            'more_link' => [],
+          ];
+          $entity->setConfiguration($configuration);
+          $entity->save();
+          break;
+      }
 
-    // We now have 6 revisions, and the last two have translations as the
-    // translation gets carried over from the published revision to the draft.
-    $this->assertRevisions('node', 6, [5, 6]);
-    $this->assertRevisions('content_moderation_state', 6, [5, 6]);
+      $this->assertRevisions($entity_type, 1);
+      $this->assertRevisions('content_moderation_state', 1);
 
-    // Go the node and validate the language dropping checkbox.
-    $this->drupalGet($node->toUrl('latest-version'));
-    $this->assertSession()->selectExists('Change to');
-    $this->assertSession()->fieldValueEquals('Change to', 'needs_review');
-    // Assert the checkbox is visible only when selecting validated or
-    // published.
-    $this->assertFalse($this->getSession()->getPage()->findField('Do not carry over the translations')->isVisible());
-    $this->getSession()->getPage()->selectFieldOption('Change to', 'request_validation');
-    $this->getSession()->wait(2);
-    $this->assertFalse($this->getSession()->getPage()->findField('Do not carry over the translations')->isVisible());
-    $this->getSession()->getPage()->selectFieldOption('Change to', 'validated');
-    $this->getSession()->wait(2);
-    $this->assertTrue($this->getSession()->getPage()->findField('Do not carry over the translations')->isVisible());
-    $this->getSession()->getPage()->selectFieldOption('Change to', 'published');
-    $this->getSession()->wait(2);
-    $this->assertTrue($this->getSession()->getPage()->findField('Do not carry over the translations')->isVisible());
+      $this->drupalGet($entity->toUrl());
 
-    // Moderate until we only have 1 step (this will create two revisions).
-    $this->getSession()->getPage()->selectFieldOption('Change to', 'request_validation');
-    $this->getSession()->getPage()->pressButton('Apply');
-    $this->waitForBatchExecution();
-    $this->assertSession()->waitForText('The moderation state has been updated.');
-    $this->assertRevisions('node', 8, [5, 6, 7, 8]);
-    $this->assertRevisions('content_moderation_state', 8, [5, 6, 7, 8]);
+      // There should be no checkbox to drop languages as we don't have any
+      // translations.
+      $this->assertSession()->selectExists('Change to');
+      $this->assertSession()->fieldNotExists('Do not carry over the translations');
 
-    // Validate and drop the translations.
-    $this->drupalGet($node->toUrl('latest-version'));
-    $this->assertSession()->fieldValueEquals('Change to', 'validated');
-    $this->getSession()->getPage()->checkField('Do not carry over the translations');
-    $this->getSession()->getPage()->pressButton('Apply');
+      // Publish the content. We use the shortcuts for that.
+      $this->getSession()->getPage()->selectFieldOption('Change to', 'published');
+      $this->getSession()->getPage()->pressButton('Apply');
+      $this->waitForBatchExecution();
+      $this->assertSession()->waitForText('The moderation state has been updated.');
 
-    // We now have an extra revision but the validated one does not have the
-    // translation.
-    $this->assertRevisions('node', 9, [5, 6, 7, 8]);
-    // Due to content moderation also handling the deletion of translations,
-    // we lose the translation of the "request_validation" revision.
-    // @see oe_translation_corporate_workflow_content_moderation_state_presave().
-    $this->assertRevisions('content_moderation_state', 9, [5, 6, 7]);
+      // We have 5 revisions all the way to published.
+      $this->assertRevisions($entity_type, 5);
+      $this->assertRevisions('content_moderation_state', 5);
 
-    // Publish the content.
-    $this->drupalGet($node->toUrl('latest-version'));
-    $this->assertSession()->fieldValueEquals('Change to', 'published');
-    // Once the content was validated, the checkbox is gone.
-    $this->assertSession()->fieldNotExists('Do not carry over the translations');
-    $this->getSession()->getPage()->pressButton('Apply');
+      // Translate the content.
+      $storage->resetCache();
+      $entity = $storage->load($entity->id());
+      $request = $this->createLocalTranslationRequest($entity, 'fr');
+      $this->drupalGet($request->toUrl('local-translation'));
+      $values = [
+        'Translation' => 'My editorial content FR',
+      ];
+      $this->submitForm($values, 'Save and synchronise');
 
-    // One more revision but still no extra translations.
-    $this->assertRevisions('node', 10, [5, 6, 7, 8]);
-    $this->assertRevisions('content_moderation_state', 10, [5, 6, 7]);
+      // We still only have 5 revisions of each and only the published one has a
+      // translation.
+      $this->assertRevisions($entity_type, 5, [5]);
+      $with_translations = $entity_type === 'node' ? [5] : [15];
+      $this->assertRevisions('content_moderation_state', 5, $with_translations);
 
-    // Assert the translation overview page no longer shows the FR translation
-    // link.
-    $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
-    $this->assertSession()->linkExistsExact('My node 2');
-    $this->assertSession()->linkNotExistsExact('My node FR');
-    $this->assertDashboardExistingTranslations([
-      'en' => ['title' => 'My node 2'],
-    ]);
+      // Assert the translation overview page shows the FR translation link.
+      $this->drupalGet($entity->toUrl('drupal:content-translation-overview'));
+      $this->assertSession()->linkExistsExact('My editorial content');
+      $this->assertEquals('Version 1.0.0', $this->getSession()->getPage()->find('xpath', '//tr[@hreflang="fr"]/td[2]')->getText());
+      $this->assertDashboardExistingTranslations([
+        'en' => ['title' => 'My editorial content'],
+        'fr' => ['title' => 'Version 1.0.0'],
+      ]);
+
+      // Create a new draft.
+      $storage->resetCache();
+      $entity = $storage->load($entity->id());
+      $entity->set($title_fields[$entity_type], 'My editorial content 2');
+      $entity->set('moderation_state', 'draft');
+      $entity->save();
+
+      // We now have 6 revisions, and the last two have translations as the
+      // translation gets carried over from the published revision to the draft.
+      $this->assertRevisions($entity_type, 6, [5, 6]);
+      $with_translations = $entity_type === 'node' ? [5, 6] : [15, 16];
+      $this->assertRevisions('content_moderation_state', 6, $with_translations);
+
+      // Go the node and validate the language dropping checkbox.
+      $this->drupalGet($entity->toUrl('latest-version'));
+      $this->assertSession()->selectExists('Change to');
+      $this->assertSession()->fieldValueEquals('Change to', 'needs_review');
+      // Assert the checkbox is visible only when selecting validated or
+      // published.
+      $this->assertFalse($this->getSession()->getPage()->findField('Do not carry over the translations')->isVisible());
+      $this->getSession()->getPage()->selectFieldOption('Change to', 'request_validation');
+      $this->getSession()->wait(2);
+      $this->assertFalse($this->getSession()->getPage()->findField('Do not carry over the translations')->isVisible());
+      $this->getSession()->getPage()->selectFieldOption('Change to', 'validated');
+      $this->getSession()->wait(2);
+      $this->assertTrue($this->getSession()->getPage()->findField('Do not carry over the translations')->isVisible());
+      $this->getSession()->getPage()->selectFieldOption('Change to', 'published');
+      $this->getSession()->wait(2);
+      $this->assertTrue($this->getSession()->getPage()->findField('Do not carry over the translations')->isVisible());
+
+      // Moderate until we only have 1 step (this will create two revisions).
+      $this->getSession()->getPage()->selectFieldOption('Change to', 'request_validation');
+      $this->getSession()->getPage()->pressButton('Apply');
+      $this->waitForBatchExecution();
+      $this->assertSession()->waitForText('The moderation state has been updated.');
+      $this->assertRevisions($entity_type, 8, [5, 6, 7, 8]);
+      $with_translations = $entity_type === 'node' ? [5, 6, 7, 8] : [15, 16, 17, 18];
+      $this->assertRevisions('content_moderation_state', 8, $with_translations);
+
+      // Validate and drop the translations.
+      $this->drupalGet($entity->toUrl('latest-version'));
+      $this->assertSession()->fieldValueEquals('Change to', 'validated');
+      $this->getSession()->getPage()->checkField('Do not carry over the translations');
+      $this->getSession()->getPage()->pressButton('Apply');
+
+      // We now have an extra revision but the validated one does not have the
+      // translation.
+      $this->assertRevisions($entity_type, 9, [5, 6, 7, 8]);
+      // Due to content moderation also handling the deletion of translations,
+      // we lose the translation of the "request_validation" revision.
+      // @see oe_translation_corporate_workflow_content_moderation_state_presave().
+      $with_translations = $entity_type === 'node' ? [5, 6, 7] : [15, 16, 17];
+      $this->assertRevisions('content_moderation_state', 9, $with_translations);
+
+      // Publish the content.
+      $this->drupalGet($entity->toUrl('latest-version'));
+      $this->assertSession()->fieldValueEquals('Change to', 'published');
+      // Once the content was validated, the checkbox is gone.
+      $this->assertSession()->fieldNotExists('Do not carry over the translations');
+      $this->getSession()->getPage()->pressButton('Apply');
+
+      // One more revision but still no extra translations.
+      $this->assertRevisions($entity_type, 10, [5, 6, 7, 8]);
+      $with_translations = $entity_type === 'node' ? [5, 6, 7] : [15, 16, 17];
+      $this->assertRevisions('content_moderation_state', 10, $with_translations);
+
+      // Assert the translation overview page no longer shows the FR translation
+      // link.
+      $this->drupalGet($entity->toUrl('drupal:content-translation-overview'));
+      $this->assertSession()->linkExistsExact('My editorial content 2');
+      $this->assertSession()->linkNotExistsExact('My editorial content FR');
+      $this->assertDashboardExistingTranslations([
+        'en' => ['title' => 'My editorial content 2'],
+      ]);
+
+      $entity->delete();
+    }
   }
 
   /**
@@ -305,7 +357,7 @@ class CorporateWorkflowTranslationDropTest extends WebDriverTestBase {
   protected function assertRevisions(string $entity_type, int $count, array $with_translations = []) {
     $storage = $this->entityTypeManager->getStorage($entity_type);
     $storage->resetCache();
-    $field = $entity_type === 'content_moderation_state' ? 'content_entity_id' : 'nid';
+    $field = $entity_type === 'content_moderation_state' ? 'content_entity_id' : $this->entityTypeManager->getDefinition($entity_type)->getKey('id');
     $revision_ids = $storage->getQuery()->condition($field, 1)->accessCheck(FALSE)->allRevisions()->execute();
     $this->assertCount($count, $revision_ids);
 

--- a/modules/oe_translation_local/oe_translation_local.services.yml
+++ b/modules/oe_translation_local/oe_translation_local.services.yml
@@ -6,7 +6,7 @@ services:
       - { name: event_subscriber }
   oe_translation_local.event_subscriber.dashboard_alter:
     class: Drupal\oe_translation_local\EventSubscriber\TranslationDashboardAlterSubscriber
-    arguments: ['@entity_type.manager', '@language_manager']
+    arguments: ['@entity_type.manager', '@language_manager', '@oe_translation.translator_providers']
     tags:
       - { name: event_subscriber }
   oe_translation_local.event_subscriber.operations_provider:

--- a/oe_translation.module
+++ b/oe_translation.module
@@ -114,8 +114,8 @@ function oe_translation_entity_access(EntityInterface $entity, $operation, Accou
   }
 
   // We do not want translations to be manually edited if they are supported
-  // by our translation system.
-  if (!$entity->isDefaultTranslation()) {
+  // by our translation system and the local translation is disabled.
+  if (!$entity->isDefaultTranslation() && $translator_providers->hasLocal($entity->getEntityType())) {
     return AccessResult::forbidden()->addCacheableDependency($entity);
   }
 

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -48,21 +48,21 @@ class RouteSubscriber extends RouteSubscriberBase {
     $entity_types = $this->translationProviders->getDefinitions();
     foreach ($entity_types as $entity_type_id => $entity_type) {
       // Change the access requirements on the Drupal core routes.
-      if ($entity_type->hasLinkTemplate('drupal:content-translation-add')) {
+      if ($entity_type->hasLinkTemplate('drupal:content-translation-add') && $this->translationProviders->hasLocal($entity_type)) {
         $route_name = "entity.$entity_type_id.content_translation_add";
         $route = $collection->get($route_name);
         $route->setRequirement('_access_oe_translation', 'create');
         $collection->add($route_name, $route);
       }
 
-      if ($entity_type->hasLinkTemplate('drupal:content-translation-edit')) {
+      if ($entity_type->hasLinkTemplate('drupal:content-translation-edit') && $this->translationProviders->hasLocal($entity_type)) {
         $route_name = "entity.$entity_type_id.content_translation_edit";
         $route = $collection->get($route_name);
         $route->setRequirement('_access_oe_translation', 'update');
         $collection->add($route_name, $route);
       }
 
-      if ($entity_type->hasLinkTemplate('drupal:content-translation-delete')) {
+      if ($entity_type->hasLinkTemplate('drupal:content-translation-delete') && $this->translationProviders->hasLocal($entity_type)) {
         $route_name = "entity.$entity_type_id.content_translation_delete";
         $route = $collection->get($route_name);
         $route->setRequirement('_access_oe_translation', 'delete');

--- a/tests/modules/oe_translation_menu_link_test/oe_translation_menu_link_test.info.yml
+++ b/tests/modules/oe_translation_menu_link_test/oe_translation_menu_link_test.info.yml
@@ -1,0 +1,13 @@
+name: OE Translation Menu Tink Test
+description: Test module for OE Translation
+core_version_requirement: ^10
+type: module
+package: Testing
+
+dependencies:
+  - oe_translation:oe_translation
+  - oe_translation:oe_translation_remote
+  - oe_translation:oe_translation_remote_test
+  - oe_multilingual_demo:oe_multilingual_demo
+  - drupal:link
+  - drupal:menu_link_content

--- a/tests/modules/oe_translation_menu_link_test/oe_translation_menu_link_test.module
+++ b/tests/modules/oe_translation_menu_link_test/oe_translation_menu_link_test.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Menu link content translation test module.
+ */
+
+/**
+ * Implements hook_entity_type_alter().
+ */
+function oe_translation_menu_link_test_entity_type_alter(array &$entity_types) {
+  /** @var \Drupal\Core\Entity\EntityTypeInterface $entity_type */
+  foreach ($entity_types as $entity_type_id => $entity_type) {
+    if ($entity_type_id === 'menu_link_content') {
+      $translators = [
+        'remote' => [
+          'remote_one',
+        ],
+      ];
+
+      $entity_type->set('oe_translation_translators', $translators);
+    }
+  }
+}

--- a/tests/src/Traits/TranslationsTestTrait.php
+++ b/tests/src/Traits/TranslationsTestTrait.php
@@ -223,6 +223,9 @@ trait TranslationsTestTrait {
     $role = Role::load('oe_translator');
     $role->grantPermission('administer menu');
     $role->grantPermission('edit any page content');
+    $role->grantPermission('translate editable entities');
+    $role->grantPermission('create content translations');
+    $role->grantPermission('update content translations');
     $role->save();
     $user = $this->drupalCreateUser();
     $user->addRole($role->id());


### PR DESCRIPTION
In this PR we allow the situation in which for an entity type, we use the remote translations but we don't also use the local translation. Instead, for local, the regular Drupal core system stays. However, there is still the override of not creating a new revision upon translation saving even for regular Drupal core translations.

We also restrict the active revision logic to nodes.