### PR TITLE
EWPP-3783: Logging incorrect incoming epoetry request translation files.

### DIFF
--- a/modules/oe_translation_epoetry/modules/oe_translation_epoetry_mock/src/EpoetryTranslationMockHelper.php
+++ b/modules/oe_translation_epoetry/modules/oe_translation_epoetry_mock/src/EpoetryTranslationMockHelper.php
@@ -66,6 +66,10 @@ class EpoetryTranslationMockHelper {
     }
 
     $exported = \Drupal::service('oe_translation_epoetry.html_formatter')->export($request);
+    if (isset(static::$translationRequestErrors['wrong request id'])) {
+      // Mimic the wrong file being sent (for a different request).
+      $exported = str_replace('item-' . $request->id(), 'item-4534353453', (string) $exported);
+    }
 
     $values = [
       '#request_id' => $request->getRequestId(),

--- a/modules/oe_translation_epoetry/src/ContentFormatter/HtmlFormatter.php
+++ b/modules/oe_translation_epoetry/src/ContentFormatter/HtmlFormatter.php
@@ -91,6 +91,16 @@ class HtmlFormatter implements ContentFormatterInterface {
       return [];
     }
 
+    $assets = $xml->xpath("//div[@class='asset']");
+    if (!$assets) {
+      return [];
+    }
+
+    $asset_id = (string) $assets[0]->attributes()['id'];
+    if ($asset_id !== 'item-' . $request->id()) {
+      throw new \Exception('The translation request file does not match the translation request.');
+    }
+
     foreach ($xml->xpath("//div[@class='atom']") as $atom) {
       $key = $this->decodeIdSafeBase64((string) $atom['id']);
       $dom->loadXML($atom->asXML());

--- a/modules/oe_translation_epoetry/src/EventSubscriber/NotificationsSubscriber.php
+++ b/modules/oe_translation_epoetry/src/EventSubscriber/NotificationsSubscriber.php
@@ -340,7 +340,16 @@ class NotificationsSubscriber implements EventSubscriberInterface {
 
     // Process the translated file.
     $file = $product->getFile();
-    $data = $this->contentFormatter->import($file, $translation_request);
+    try {
+      $data = $this->contentFormatter->import($file, $translation_request);
+    }
+    catch (\Exception $exception) {
+      $event->setErrorResponse($exception->getMessage());
+      $reference = $this->formatRequestReference($product->getProductReference()->getRequestReference());
+      $this->logger->error('The ePoetry notification did not provide a valid translation. ' . $exception->getMessage() . ' Reference: <strong>@reference</strong>.', ['@reference' => $reference]);
+      return;
+    }
+
     if (!$data) {
       $event->setErrorResponse('Translation data is missing or is invalid.');
       $reference = $this->formatRequestReference($product->getProductReference()->getRequestReference());

--- a/modules/oe_translation_epoetry/tests/fixtures/formatted-content-translated.html
+++ b/modules/oe_translation_epoetry/tests/fixtures/formatted-content-translated.html
@@ -8,7 +8,7 @@
     <title>Request ID @request_id</title>
   </head>
   <body>
-          <div class="asset" id="item-1">
+          <div class="asset" id="item-@request_id">
                   <!--
           label="Title"
           context="[1][title][0][value]"

--- a/modules/oe_translation_epoetry/tests/src/FunctionalJavascript/EpoetryTranslationTest.php
+++ b/modules/oe_translation_epoetry/tests/src/FunctionalJavascript/EpoetryTranslationTest.php
@@ -1622,6 +1622,18 @@ class EpoetryTranslationTest extends TranslationTestBase {
     $this->assertStringContainsString('The ePoetry notification did not provide a valid translation. Reference:', $log['message']);
     $log = $logs[4];
     $this->assertStringContainsString('<success>false</success><message>Translation data is missing or is invalid.</message>', $log['context']['response']);
+
+    // Translate the request with the file of a different request.
+    $request = TranslationRequest::load($request->id());
+    \Drupal::service('oe_translation_epoetry_mock.logger.mock_logger')->clearLogs();
+    unset(EpoetryTranslationMockHelper::$translationRequestErrors['missing translation']);
+    EpoetryTranslationMockHelper::$translationRequestErrors['wrong request id'] = TRUE;
+    EpoetryTranslationMockHelper::translateRequest($request, 'fr');
+    $logs = \Drupal::service('oe_translation_epoetry_mock.logger.mock_logger')->getLogs();
+    $log = $logs[3];
+    $this->assertStringContainsString('The ePoetry notification did not provide a valid translation. The translation request file does not match the translation request. Reference:', $log['message']);
+    $log = $logs[4];
+    $this->assertStringContainsString('<success>false</success><message>The translation request file does not match the translation request.</message>', $log['context']['response']);
   }
 
   /**

--- a/modules/oe_translation_epoetry/tests/src/Kernel/HtmlFormatterTest.php
+++ b/modules/oe_translation_epoetry/tests/src/Kernel/HtmlFormatterTest.php
@@ -168,6 +168,19 @@ class HtmlFormatterTest extends TranslationKernelTestBase {
 
     $formatted_content = file_get_contents(\Drupal::service('extension.path.resolver')->getPath('module', 'oe_translation_epoetry') . '/tests/fixtures/formatted-content-translated.html');
 
+    // Assert we get an exception if we try to import the content of a wrong
+    // request.
+    $test_formatted_content = str_replace('@request_id', '265445', $formatted_content);
+    $exception = NULL;
+    try {
+      $formatter->import($test_formatted_content, $this->request);
+    }
+    catch (\Exception $exception) {
+    }
+    $this->assertEquals('The translation request file does not match the translation request.', $exception->getMessage());
+    $this->assertInstanceOf(\Exception::class, $exception);
+
+    $formatted_content = str_replace('@request_id', $this->request->id(), $formatted_content);
     $actual_data = $formatter->import($formatted_content, $this->request);
 
     $expected_data = [


### PR DESCRIPTION
In case the translators send the file of another translation request, we need to log this and return a proper error.