### PR TITLE
D8AGE-542: Fix handling of container parameters.

### DIFF
--- a/modules/oe_translation_cdt/oe_translation_cdt.services.yml
+++ b/modules/oe_translation_cdt/oe_translation_cdt.services.yml
@@ -5,7 +5,7 @@ services:
       - '@http_client'
       - '@psr17.server_request_factory'
       - '@psr17.stream_factory'
-      - '%cdt.client_configuration%'
+      - { client: '%cdt.client%', username: '%cdt.username%', password: '%cdt.password%', apiBaseUrl: '%cdt.base_api_url%' }
 
   oe_translation_cdt.api_wrapper:
     class: Drupal\oe_translation_cdt\Api\CdtApiWrapper

--- a/modules/oe_translation_cdt/src/Compiler/CdtParametersCompilerPass.php
+++ b/modules/oe_translation_cdt/src/Compiler/CdtParametersCompilerPass.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * Registers the cdt.client_configuration container parameter.
+ * Registers the container parameters used by the CDT.
  */
 class CdtParametersCompilerPass implements CompilerPassInterface {
 
@@ -20,6 +20,7 @@ class CdtParametersCompilerPass implements CompilerPassInterface {
     // The container parameters can't be added as a single array.
     // Array values don't support the "%" character, that may
     // appear in the password or in the URL.
+    // @see https://www.drupal.org/project/drupal/issues/3458344
     $container->setParameter('cdt.base_api_url', Settings::get('cdt.base_api_url'));
     $container->setParameter('cdt.username', Settings::get('cdt.username'));
     $container->setParameter('cdt.password', Settings::get('cdt.password'));

--- a/modules/oe_translation_cdt/src/Compiler/CdtParametersCompilerPass.php
+++ b/modules/oe_translation_cdt/src/Compiler/CdtParametersCompilerPass.php
@@ -17,12 +17,13 @@ class CdtParametersCompilerPass implements CompilerPassInterface {
    * {@inheritdoc}
    */
   public function process(ContainerBuilder $container): void {
-    $container->setParameter('cdt.client_configuration', [
-      'apiBaseUrl' => Settings::get('cdt.base_api_url'),
-      'username' => Settings::get('cdt.username'),
-      'password' => Settings::get('cdt.password'),
-      'client' => Settings::get('cdt.client'),
-    ]);
+    // The container parameters can't be added as a single array.
+    // Array values don't support the "%" character, that may
+    // appear in the password or in the URL.
+    $container->setParameter('cdt.base_api_url', Settings::get('cdt.base_api_url'));
+    $container->setParameter('cdt.username', Settings::get('cdt.username'));
+    $container->setParameter('cdt.password', Settings::get('cdt.password'));
+    $container->setParameter('cdt.client', Settings::get('cdt.client'));
   }
 
 }

--- a/modules/oe_translation_cdt/src/Compiler/CdtParametersCompilerPass.php
+++ b/modules/oe_translation_cdt/src/Compiler/CdtParametersCompilerPass.php
@@ -21,10 +21,10 @@ class CdtParametersCompilerPass implements CompilerPassInterface {
     // Array values don't support the "%" character, that may
     // appear in the password or in the URL.
     // @see https://www.drupal.org/project/drupal/issues/3458344
-    $container->setParameter('cdt.base_api_url', Settings::get('cdt.base_api_url'));
-    $container->setParameter('cdt.username', Settings::get('cdt.username'));
-    $container->setParameter('cdt.password', Settings::get('cdt.password'));
-    $container->setParameter('cdt.client', Settings::get('cdt.client'));
+    $container->setParameter('cdt.base_api_url', str_replace("%", "%%", Settings::get('cdt.base_api_url', '')));
+    $container->setParameter('cdt.username', str_replace("%", "%%", Settings::get('cdt.username', '')));
+    $container->setParameter('cdt.password', str_replace("%", "%%", Settings::get('cdt.password', '')));
+    $container->setParameter('cdt.client', str_replace("%", "%%", Settings::get('cdt.client', '')));
   }
 
 }

--- a/modules/oe_translation_cdt/tests/src/Kernel/CdtParametersCompilerPassTest.php
+++ b/modules/oe_translation_cdt/tests/src/Kernel/CdtParametersCompilerPassTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\oe_translation_cdt\Kernel;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Site\Settings;
+use Drupal\oe_translation_cdt\Compiler\CdtParametersCompilerPass;
+use Drupal\Tests\oe_translation\Kernel\TranslationKernelTestBase;
+
+/**
+ * Tests the compiler pass that sets CDT configuration.
+ *
+ * @group batch1
+ */
+class CdtParametersCompilerPassTest extends TranslationKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'oe_translation_cdt',
+    'oe_translation_remote',
+  ];
+
+  /**
+   * Tests that the CDT configuration is passed properly to the container.
+   */
+  public function testCdtCompilerPass(): void {
+    // Define strings with "%" characters, that need to be escaped.
+    $settings = [
+      'cdt.base_api_url' => '%url%',
+      'cdt.username' => '%username!@#$^&*()_+=-,./?;test',
+      'cdt.client' => '%%client%%',
+      'cdt.password' => 'test_%%password%',
+      'cdt.api_key' => 'test_%api_key',
+    ];
+    new Settings($settings);
+
+    // Define a simple inline class that will receive the parameters.
+    $receiver_object = new class {
+
+      /**
+       * Constructs the parameter receiver object.
+       */
+      public function __construct(public array $configuration = []) {
+      }
+
+    };
+
+    // Create a new container and register the compiler pass.
+    $container = new ContainerBuilder();
+    $container->addCompilerPass(new CdtParametersCompilerPass());
+    $container->register('parameter_receiver', get_class($receiver_object))
+      ->addArgument([
+        'client' => '%cdt.client%',
+        'username' => '%cdt.username%',
+        'password' => '%cdt.password%',
+        'apiBaseUrl' => '%cdt.base_api_url%',
+      ]);
+    $container->compile();
+
+    // Assert the configuration values.
+    $receiver_service = $container->get('parameter_receiver');
+    assert($receiver_service instanceof $receiver_object);
+    $this->assertEquals($receiver_service->configuration['apiBaseUrl'], '%url%');
+    $this->assertEquals($receiver_service->configuration['username'], '%username!@#$^&*()_+=-,./?;test');
+    $this->assertEquals($receiver_service->configuration['client'], '%%client%%');
+    $this->assertEquals($receiver_service->configuration['password'], 'test_%%password%');
+  }
+
+}


### PR DESCRIPTION
## D8AGE-542

### Description

Fix handling of container parameters. When we add them as an array, Drupal replaces `%` characters with `%%`, and it does this twice in `OptimizedPhpArrayDumper.php`. I'm not sure if this is a bug, but the password `ab%c` becomes `ab%%%%c`.