### PR TITLE
D8AGE-370: Adapt the module code to work with collections.

### DIFF
--- a/modules/oe_translation_cdt/src/TranslationRequestUpdater.php
+++ b/modules/oe_translation_cdt/src/TranslationRequestUpdater.php
@@ -41,7 +41,7 @@ final class TranslationRequestUpdater implements TranslationRequestUpdaterInterf
    * {@inheritdoc}
    */
   public function updateFromTranslationResponse(TranslationRequestCdtInterface $translation_request, Translation $translation_response, ReferenceData $reference_data): bool {
-    $comments = trim(array_reduce($translation_response->getComments(), function ($carry, $item) {
+    $comments = trim(array_reduce((array) $translation_response->getComments(), function ($carry, $item) {
       return $carry . $item->getComment() . "\n";
     }, ''), "\n");
 

--- a/modules/oe_translation_cdt/tests/src/Kernel/TranslationRequestMapperTest.php
+++ b/modules/oe_translation_cdt/tests/src/Kernel/TranslationRequestMapperTest.php
@@ -99,12 +99,12 @@ class TranslationRequestMapperTest extends TranslationKernelTestBase {
     $this->assertEquals('Send', $dto->getSendOptions());
     $this->assertEquals('WS', $dto->getPurposeCode());
     $this->assertEquals($test_data['department'], $dto->getDepartmentCode());
-    $this->assertEquals($test_data['contact_usernames'], $dto->getContactUserNames());
-    $this->assertEquals($test_data['deliver_to'], $dto->getDeliveryContactUsernames());
+    $this->assertEquals($test_data['contact_usernames'], (array) $dto->getContactUserNames());
+    $this->assertEquals($test_data['deliver_to'], (array) $dto->getDeliveryContactUsernames());
     $this->assertEquals($test_data['priority'], $dto->getPriorityCode());
 
     $source_document = $dto->getSourceDocuments()[0];
-    $this->assertEquals(['EN'], $source_document->getSourceLanguages());
+    $this->assertEquals(['EN'], (array) $source_document->getSourceLanguages());
     $this->assertFalse($source_document->isPrivate());
     $this->assertEquals('XM', $source_document->getOutputDocumentFormatCode());
     $this->assertEquals($test_data['confidentiality'], $source_document->getConfidentialityCode());


### PR DESCRIPTION
## D8AGE-370 

### Description
The ticket changes all DTO arrays to strict-typed object collections. Therefore, the `oe_translation_cdt` module needs to be updated to support the new data structures. Collections are mostly compatible with arrays, so only minor changes are required. 