### PR TITLE
D8AGE-871: Fix the callback URLs in the translation request.

### DIFF
--- a/modules/oe_translation_cdt/modules/oe_translation_cdt_mock/oe_translation_cdt_mock.install
+++ b/modules/oe_translation_cdt/modules/oe_translation_cdt_mock/oe_translation_cdt_mock.install
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * OE Translation CDT Mock install file.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Implements hook_install().
+ */
+function oe_translation_cdt_mock_install($is_syncing) {
+  \Drupal::state()->delete('cdt.token');
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function oe_translation_cdt_mock_uninstall($is_syncing) {
+  \Drupal::state()->delete('cdt.token');
+}

--- a/modules/oe_translation_cdt/modules/oe_translation_cdt_mock/tests/src/Unit/ServiceMockBaseTest.php
+++ b/modules/oe_translation_cdt/modules/oe_translation_cdt_mock/tests/src/Unit/ServiceMockBaseTest.php
@@ -8,8 +8,8 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleExtensionList;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Site\Settings;
-use Drupal\oe_translation_cdt_mock\Plugin\ServiceMock\ServiceMockBase;
 use Drupal\Tests\UnitTestCase;
+use Drupal\oe_translation_cdt_mock\Plugin\ServiceMock\ServiceMockBase;
 use GuzzleHttp\Psr7\Request;
 
 /**

--- a/modules/oe_translation_cdt/src/Mapper/TranslationRequestMapper.php
+++ b/modules/oe_translation_cdt/src/Mapper/TranslationRequestMapper.php
@@ -175,14 +175,14 @@ class TranslationRequestMapper implements TranslationRequestMapperInterface {
   protected function createCallbacks(): CallbackCollection {
     // Set the LANGUAGE_NOT_SPECIFIED to avoid the language suffix in the URL.
     // @see \Drupal\language\Plugin\LanguageNegotiation\LanguageNegotiationUrl::processOutbound()
-    $job_status_url = Url::fromRoute(
+    $request_status_url = Url::fromRoute(
       route_name: 'oe_translation_cdt.request_status_callback',
       options: [
         'absolute' => TRUE,
         'language' => new Language(['id' => LanguageInterface::LANGCODE_NOT_SPECIFIED]),
       ],
     );
-    $request_status_url = Url::fromRoute(
+    $job_status_url = Url::fromRoute(
       route_name: 'oe_translation_cdt.job_status_callback',
       options: [
         'absolute' => TRUE,

--- a/modules/oe_translation_cdt/src/TranslationRequestUpdater.php
+++ b/modules/oe_translation_cdt/src/TranslationRequestUpdater.php
@@ -117,7 +117,7 @@ final class TranslationRequestUpdater implements TranslationRequestUpdaterInterf
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  protected function updateFieldset(TranslationRequestCdtInterface $translation_request, array $fields, string $global_message = NULL): bool {
+  protected function updateFieldset(TranslationRequestCdtInterface $translation_request, array $fields, ?string $global_message = NULL): bool {
     $cumulated_changes = [];
     $cumulated_variables = [];
     foreach ($fields as $field => $value) {

--- a/modules/oe_translation_cdt/tests/src/FunctionalJavascript/TranslationProviderTest.php
+++ b/modules/oe_translation_cdt/tests/src/FunctionalJavascript/TranslationProviderTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\oe_translation_cdt\FunctionalJavascript;
 
+use Drupal\Tests\oe_translation\FunctionalJavascript\TranslationTestBase;
+use Drupal\Tests\oe_translation\Traits\TranslationsTestTrait;
+use Drupal\Tests\oe_translation_remote\Traits\RemoteTranslationsTestTrait;
 use Drupal\oe_translation\LanguageWithStatus;
 use Drupal\oe_translation_cdt\TranslationRequestCdtInterface;
 use Drupal\oe_translation_remote\Entity\RemoteTranslatorProvider;
 use Drupal\oe_translation_remote\Entity\RemoteTranslatorProviderInterface;
 use Drupal\oe_translation_remote\TranslationRequestRemoteInterface;
-use Drupal\Tests\oe_translation\FunctionalJavascript\TranslationTestBase;
-use Drupal\Tests\oe_translation\Traits\TranslationsTestTrait;
-use Drupal\Tests\oe_translation_remote\Traits\RemoteTranslationsTestTrait;
 use Drupal\user\UserInterface;
 
 /**

--- a/modules/oe_translation_cdt/tests/src/Kernel/CallbackControllerTest.php
+++ b/modules/oe_translation_cdt/tests/src/Kernel/CallbackControllerTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Drupal\Tests\oe_translation_cdt\Kernel;
 
 use Drupal\Core\Site\Settings;
+use Drupal\Tests\oe_translation\Kernel\TranslationKernelTestBase;
 use Drupal\oe_translation\Entity\TranslationRequest;
 use Drupal\oe_translation_cdt\Api\CdtApiWrapperInterface;
 use Drupal\oe_translation_cdt\Controller\CallbackController;
 use Drupal\oe_translation_cdt\TranslationRequestCdtInterface;
 use Drupal\oe_translation_remote\TranslationRequestRemoteInterface;
-use Drupal\Tests\oe_translation\Kernel\TranslationKernelTestBase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/modules/oe_translation_cdt/tests/src/Kernel/CdtAccessTest.php
+++ b/modules/oe_translation_cdt/tests/src/Kernel/CdtAccessTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Drupal\Tests\oe_translation_cdt\Kernel;
 
 use Drupal\Core\Session\AccountInterface;
-use Drupal\oe_translation_cdt\Access\CdtAccessCheck;
-use Drupal\oe_translation_remote\Entity\RemoteTranslatorProviderInterface;
 use Drupal\Tests\oe_translation\Kernel\TranslationKernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\oe_translation_cdt\Access\CdtAccessCheck;
+use Drupal\oe_translation_remote\Entity\RemoteTranslatorProviderInterface;
 
 /**
  * Tests the access handler of CDT.

--- a/modules/oe_translation_cdt/tests/src/Kernel/CdtParametersCompilerPassTest.php
+++ b/modules/oe_translation_cdt/tests/src/Kernel/CdtParametersCompilerPassTest.php
@@ -6,8 +6,8 @@ namespace Drupal\Tests\oe_translation_cdt\Kernel;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Site\Settings;
-use Drupal\oe_translation_cdt\Compiler\CdtParametersCompilerPass;
 use Drupal\Tests\oe_translation\Kernel\TranslationKernelTestBase;
+use Drupal\oe_translation_cdt\Compiler\CdtParametersCompilerPass;
 
 /**
  * Tests the compiler pass that sets CDT configuration.

--- a/modules/oe_translation_cdt/tests/src/Kernel/TargetLanguagesWithTooltipTest.php
+++ b/modules/oe_translation_cdt/tests/src/Kernel/TargetLanguagesWithTooltipTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Drupal\Tests\oe_translation_cdt\Kernel;
 
 use Drupal\Core\Render\RenderContext;
+use Drupal\Tests\oe_translation\Kernel\TranslationKernelTestBase;
 use Drupal\oe_translation_cdt\Plugin\views\field\TargetLanguagesWithTooltip;
 use Drupal\oe_translation_cdt\TranslationRequestCdt;
 use Drupal\oe_translation_cdt\TranslationRequestCdtInterface;
 use Drupal\oe_translation_remote\TranslationRequestRemoteInterface;
-use Drupal\Tests\oe_translation\Kernel\TranslationKernelTestBase;
 use Drupal\views\ResultRow;
 
 /**

--- a/modules/oe_translation_cdt/tests/src/Kernel/TranslationRequestBundleClassTest.php
+++ b/modules/oe_translation_cdt/tests/src/Kernel/TranslationRequestBundleClassTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\oe_translation_cdt\Kernel;
 
+use Drupal\Tests\oe_translation\Kernel\TranslationKernelTestBase;
 use Drupal\oe_translation\Entity\TranslationRequest;
 use Drupal\oe_translation_cdt\TranslationRequestCdtInterface;
-use Drupal\Tests\oe_translation\Kernel\TranslationKernelTestBase;
 
 /**
  * Tests the CDT bundle class for "Translation Request" entity.

--- a/modules/oe_translation_cdt/tests/src/Kernel/TranslationRequestMapperTest.php
+++ b/modules/oe_translation_cdt/tests/src/Kernel/TranslationRequestMapperTest.php
@@ -124,14 +124,21 @@ class TranslationRequestMapperTest extends TranslationKernelTestBase {
       $file->getFileName()
     );
 
+    $expected_callback_types = [
+      'JOB_STATUS' => '/translation-request/cdt/job-status',
+      'REQUEST_STATUS' => '/translation-request/cdt/request-status',
+    ];
     $callbacks = $dto->getCallbacks();
-    foreach (['JOB_STATUS', 'REQUEST_STATUS'] as $key => $callback_type) {
-      $this->assertEquals('test_api_key', $callbacks[$key]->getClientApiKey());
-      $this->assertTrue(UrlHelper::isValid($callbacks[$key]->getCallbackBaseUrl()));
-      $this->assertTrue(UrlHelper::isExternal($callbacks[$key]->getCallbackBaseUrl()));
+    $this->assertCount(2, $callbacks, 'Two callbacks are expected.');
+    foreach ($callbacks as $callback_dto) {
+      $callback_type = $callback_dto->getCallbackType();
+      $this->assertArrayHasKey($callback_type, $expected_callback_types, 'Unrecognized callback type.');
+      $this->assertEquals('test_api_key', $callback_dto->getClientApiKey(), 'The callback API key doesn\'t match.');
+      $this->assertTrue(UrlHelper::isValid($callback_dto->getCallbackBaseUrl()));
+      $this->assertTrue(UrlHelper::isExternal($callback_dto->getCallbackBaseUrl()));
       $base_url = $this->container->get('router.request_context')->getCompleteBaseUrl();
       $this->assertTrue(UrlHelper::externalIsLocal($callbacks[$key]->getCallbackBaseUrl(), $base_url));
-      $this->assertEquals($callback_type, $callbacks[$key]->getCallbackType());
+      $this->assertStringEndsWith($expected_callback_types[$callback_type], $callback_dto->getCallbackBaseUrl());
     }
   }
 

--- a/modules/oe_translation_cdt/tests/src/Kernel/TranslationRequestMapperTest.php
+++ b/modules/oe_translation_cdt/tests/src/Kernel/TranslationRequestMapperTest.php
@@ -7,12 +7,12 @@ namespace Drupal\Tests\oe_translation_cdt\Kernel;
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Site\Settings;
+use Drupal\Tests\oe_translation\Kernel\TranslationKernelTestBase;
+use Drupal\Tests\oe_translation_cdt\Traits\CdtTranslationTestTrait;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\oe_translation_cdt\Mapper\TranslationRequestMapper;
-use Drupal\Tests\oe_translation\Kernel\TranslationKernelTestBase;
-use Drupal\Tests\oe_translation_cdt\Traits\CdtTranslationTestTrait;
 
 /**
  * Tests the TranslationRequestMapper class.

--- a/modules/oe_translation_cdt/tests/src/Kernel/TranslationRequestUpdaterTest.php
+++ b/modules/oe_translation_cdt/tests/src/Kernel/TranslationRequestUpdaterTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\oe_translation_cdt\Kernel;
 
+use Drupal\Tests\oe_translation\Kernel\TranslationKernelTestBase;
+use Drupal\Tests\oe_translation_cdt\Traits\CdtTranslationTestTrait;
 use Drupal\oe_translation_cdt\Api\CdtApiWrapperInterface;
 use Drupal\oe_translation_cdt\TranslationRequestCdtInterface;
 use Drupal\oe_translation_cdt\TranslationRequestUpdaterInterface;
 use Drupal\oe_translation_remote\TranslationRequestRemoteInterface;
-use Drupal\Tests\oe_translation\Kernel\TranslationKernelTestBase;
-use Drupal\Tests\oe_translation_cdt\Traits\CdtTranslationTestTrait;
 use OpenEuropa\CdtClient\Model\Callback\JobStatus;
 use OpenEuropa\CdtClient\Model\Callback\RequestStatus;
 use OpenEuropa\CdtClient\Model\Response\Comment;

--- a/modules/oe_translation_cdt/tests/src/Kernel/XmlFormatterTest.php
+++ b/modules/oe_translation_cdt/tests/src/Kernel/XmlFormatterTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\oe_translation_cdt\Kernel;
 
 use Composer\InstalledVersions;
 use Drupal\Component\Datetime\Time;
+use Drupal\Tests\oe_translation\Kernel\TranslationKernelTestBase;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\filter\Entity\FilterFormat;
@@ -14,7 +15,6 @@ use Drupal\oe_translation_cdt\ContentFormatter\ContentFormatterInterface;
 use Drupal\oe_translation_cdt\TranslationRequestCdt;
 use Drupal\oe_translation_cdt\TranslationRequestCdtInterface;
 use Drupal\oe_translation_remote\TranslationRequestRemoteInterface;
-use Drupal\Tests\oe_translation\Kernel\TranslationKernelTestBase;
 
 /**
  * Tests the CDT XML content formatter.


### PR DESCRIPTION
## D8AGE-871

### Description

Right now, the callbacks in the `modules/oe_translation_cdt/src/Mapper/TranslationRequestMapper.php:173` file are assigned to wrong routes. The `oe_translation_cdt.request_status_callback` should be assigned to `$request_status_url`

