### PR TITLE
EWPP-5269: Remote translation creation permission segregation.

### DIFF
--- a/modules/oe_translation_corporate_workflow/modules/oe_translation_corporate_workflow_epoetry/tests/src/FunctionalJavascript/CorporateWorkflowEpoetryTranslationTest.php
+++ b/modules/oe_translation_corporate_workflow/modules/oe_translation_corporate_workflow_epoetry/tests/src/FunctionalJavascript/CorporateWorkflowEpoetryTranslationTest.php
@@ -12,6 +12,7 @@ use Drupal\oe_translation_corporate_workflow\CorporateWorkflowTranslationTrait;
 use Drupal\oe_translation_epoetry\TranslationRequestEpoetryInterface;
 use Drupal\oe_translation_epoetry_mock\EpoetryTranslationMockHelper;
 use Drupal\oe_translation_remote\Entity\RemoteTranslatorProvider;
+use Drupal\user\Entity\Role;
 
 /**
  * Tests the ePoetry translations with corporate workflow.
@@ -111,6 +112,9 @@ class CorporateWorkflowEpoetryTranslationTest extends WebDriverTestBase {
     $provider->save();
 
     $this->user = $this->setUpTranslatorUser();
+    $role = Role::load('oe_translator');
+    $role->grantPermission('request epoetry translation');
+    $role->save();
     $this->drupalLogin($this->user);
   }
 

--- a/modules/oe_translation_epoetry/oe_translation_epoetry.permissions.yml
+++ b/modules/oe_translation_epoetry/oe_translation_epoetry.permissions.yml
@@ -1,0 +1,2 @@
+request epoetry translation:
+  title: Request ePoetry translation

--- a/modules/oe_translation_epoetry/src/Controller/EpoetryController.php
+++ b/modules/oe_translation_epoetry/src/Controller/EpoetryController.php
@@ -232,7 +232,7 @@ class EpoetryController extends ControllerBase {
     $cache->addCacheContexts(['user.permissions']);
     $cache->addCacheableDependency($translation_request);
 
-    if (!$account->hasPermission('translate any entity')) {
+    if (!$account->hasPermission('translate any entity') || !$account->hasPermission('request epoetry translation')) {
       return AccessResult::forbidden()->addCacheableDependency($cache);
     }
 

--- a/modules/oe_translation_epoetry/src/Form/ModifyLinguisticRequestForm.php
+++ b/modules/oe_translation_epoetry/src/Form/ModifyLinguisticRequestForm.php
@@ -124,7 +124,7 @@ class ModifyLinguisticRequestForm extends FormBase {
     $cache->addCacheContexts(['user.permissions']);
     $cache->addCacheableDependency($translation_request);
 
-    if (!$account->hasPermission('translate any entity')) {
+    if (!$account->hasPermission('translate any entity') || !$account->hasPermission('request epoetry translation')) {
       return AccessResult::forbidden()->addCacheableDependency($cache);
     }
 

--- a/modules/oe_translation_epoetry/src/Plugin/RemoteTranslationProvider/Epoetry.php
+++ b/modules/oe_translation_epoetry/src/Plugin/RemoteTranslationProvider/Epoetry.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Drupal\oe_translation_epoetry\Plugin\RemoteTranslationProvider;
 
 use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Datetime\DateHelper;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\ContentEntityInterface;
@@ -12,6 +14,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\oe_translation\Entity\TranslationRequestLogInterface;
 use Drupal\oe_translation\Event\AvailableLanguagesAlterEvent;
@@ -124,6 +127,13 @@ class Epoetry extends RemoteTranslationProviderBase {
       return isset($default_configuration[$key]);
     }, ARRAY_FILTER_USE_BOTH);
     $this->configuration = $configuration + $default_configuration;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createAccess(?AccountInterface $account = NULL): AccessResultInterface {
+    return AccessResult::allowedIfHasPermission($account, 'request epoetry translation');
   }
 
   /**

--- a/modules/oe_translation_epoetry/tests/src/FunctionalJavascript/EpoetryTranslationTest.php
+++ b/modules/oe_translation_epoetry/tests/src/FunctionalJavascript/EpoetryTranslationTest.php
@@ -20,6 +20,7 @@ use Drupal\oe_translation_epoetry\TranslationRequestEpoetryInterface;
 use Drupal\oe_translation_epoetry_mock\EpoetryTranslationMockHelper;
 use Drupal\oe_translation_remote\Entity\RemoteTranslatorProvider;
 use Drupal\oe_translation_remote\TranslationRequestRemoteInterface;
+use Drupal\user\Entity\Role;
 
 /**
  * Tests the remote translations via ePoetry.
@@ -75,6 +76,9 @@ class EpoetryTranslationTest extends TranslationTestBase {
     $provider->save();
 
     $this->user = $this->setUpTranslatorUser();
+    $role = Role::load('oe_translator');
+    $role->grantPermission('request epoetry translation');
+    $role->save();
     $this->drupalLogin($this->user);
   }
 

--- a/modules/oe_translation_poetry_legacy/tests/src/FunctionalJavascript/LegacyPoetryReferenceTest.php
+++ b/modules/oe_translation_poetry_legacy/tests/src/FunctionalJavascript/LegacyPoetryReferenceTest.php
@@ -10,6 +10,7 @@ use Drupal\node\Entity\Node;
 use Drupal\oe_translation_epoetry_mock\EpoetryTranslationMockHelper;
 use Drupal\oe_translation_poetry_legacy\Entity\LegacyPoetryReference;
 use Drupal\oe_translation_remote\Entity\RemoteTranslatorProvider;
+use Drupal\user\Entity\Role;
 
 /**
  * Tests the Legacy Poetry reference entity.
@@ -150,6 +151,9 @@ class LegacyPoetryReferenceTest extends TranslationTestBase {
     $provider->save();
 
     $user = $this->setUpTranslatorUser();
+    $role = Role::load('oe_translator');
+    $role->grantPermission('request epoetry translation');
+    $role->save();
     $this->drupalLogin($user);
 
     // Create a node and a legacy ID for it.

--- a/modules/oe_translation_remote/src/Form/RemoteTranslationNewForm.php
+++ b/modules/oe_translation_remote/src/Form/RemoteTranslationNewForm.php
@@ -131,6 +131,11 @@ class RemoteTranslationNewForm extends FormBase {
     $translators = $this->entityTypeManager->getStorage('remote_translation_provider')->loadByProperties(['enabled' => TRUE]);
     $options = [];
     foreach ($translators as $translator) {
+      $plugin = $this->providerManager->createInstance($translator->getProviderPlugin(), $translator->getProviderConfiguration());
+      $access = $plugin->createAccess($this->account);
+      if (!$access->isAllowed()) {
+        continue;
+      }
       $options[$translator->id()] = $translator->label();
     }
 

--- a/modules/oe_translation_remote/src/Plugin/RemoteTranslationProviderBase.php
+++ b/modules/oe_translation_remote/src/Plugin/RemoteTranslationProviderBase.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Drupal\oe_translation_remote\Plugin;
 
 use Drupal\Component\Plugin\ConfigurableInterface;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -13,6 +15,7 @@ use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginBase;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\oe_translation\TranslationSourceManagerInterface;
 use Drupal\oe_translation_remote\RemoteTranslationProviderInterface;
@@ -165,5 +168,13 @@ abstract class RemoteTranslationProviderBase extends PluginBase implements Remot
    * {@inheritdoc}
    */
   public function validateRequest(array &$form, FormStateInterface $form_state): void {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createAccess(?AccountInterface $account = NULL): AccessResultInterface {
+    // By default, they are allowed.
+    return AccessResult::allowed();
+  }
 
 }

--- a/modules/oe_translation_remote/src/RemoteTranslationProviderInterface.php
+++ b/modules/oe_translation_remote/src/RemoteTranslationProviderInterface.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Drupal\oe_translation_remote;
 
+use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\PluginFormInterface;
+use Drupal\Core\Session\AccountInterface;
 
 /**
  * Interface for remote_translation_provider plugins.
@@ -69,5 +71,13 @@ interface RemoteTranslationProviderInterface extends PluginFormInterface {
    *   The current state of the form.
    */
   public function validateRequest(array &$form, FormStateInterface $form_state): void;
+
+  /**
+   * Determines if the user has access to make a new request.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access.
+   */
+  public function createAccess(?AccountInterface $account = NULL): AccessResultInterface;
 
 }


### PR DESCRIPTION
We introduce an access check ability on the remote translator providers so that we can separate the access between requesting translations and managing them later in Drupal.

And with this we create an epoetry specific permission that needs to be added to your role.