### PR TITLE
EWPP-6663: Requiring doctrine/annotations until we deprecate it.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,13 @@
     "require": {
         "php": ">=8.1",
         "cweagans/composer-patches": "^1.7 || ^2",
+        "doctrine/annotations": "^2",
         "drupal/core": "^10.3 || ^11",
         "jakeasmith/http_build_url": "^1.0",
         "php-http/guzzle7-adapter": "^1.0"
     },
     "require-dev": {
         "composer/installers": "^2.3",
-        "doctrine/annotations": "^2.0",
         "drupal/address": "^2.0.1",
         "drupal/block_field": "^1.0@RC",
         "drupal/config_devel": "^1.2",


### PR DESCRIPTION
It seems core 10.6 doesn't require it for some reason, and 11.1 and 11.2 do (?!)...